### PR TITLE
Kinder und Partner "löschen" funktioniert wieder

### DIFF
--- a/Eventbus/src/main/java/de/muenchen/eventbus/types/EventType.java
+++ b/Eventbus/src/main/java/de/muenchen/eventbus/types/EventType.java
@@ -19,7 +19,7 @@ public enum EventType {
     QUERY_CHILD,
     SAVE_CHILD,
     RELEASE,
-    RELEASE_PARENT,
+    RELEASE_KIND,
     RELEASE_PARTNER,
     SAVE_AS_CHILD,
     ADD_SEARCHED_CHILD,

--- a/vaadin-demo-micro-service/src/main/java/de/muenchen/demo/service/domain/Buerger.java
+++ b/vaadin-demo-micro-service/src/main/java/de/muenchen/demo/service/domain/Buerger.java
@@ -4,15 +4,7 @@ import de.muenchen.auditing.MUCAudited;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import javax.persistence.Transient;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.Date;

--- a/vaadin-demo-micro-service/src/main/resources/db/migration/V1__Init.sql
+++ b/vaadin-demo-micro-service/src/main/resources/db/migration/V1__Init.sql
@@ -63,18 +63,6 @@ buer_vorname varchar(70),
 mandant varchar(20), 
 primary key (oid));
 
---Buerger_Kinder Table
-create table buerger_kinder (
-buerger bigint not null, 
-kinder bigint not null, 
-primary key (buerger, kinder));
-
---Buerger_Partner Table
-create table buerger_partner (
-buerger bigint not null, 
-partner bigint not null, 
-primary key (buerger, partner));
-
 --Buerger_Pass Table
 create table buerger_pass (
 buerger bigint not null, 
@@ -237,15 +225,6 @@ add constraint FK_authoritys_permissions_TO_permissions
 foreign key (permission_oid) 
 references permissions;
 
-alter table buerger_kinder 
-add constraint FK_buerger_kinder_TO_kinder 
-foreign key (kinder) 
-references buerger;
-
-alter table buerger_kinder 
-add constraint FK_buerger_kinder_TO_buerger 
-foreign key (buerger) 
-references buerger;
 
 alter table buerger_pass 
 add constraint FK_buerger_pass_TO_pass 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerPartnerTab.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerPartnerTab.java
@@ -71,7 +71,6 @@ public class BuergerPartnerTab extends CustomComponent implements Consumer<Event
             LOG.debug("seleted buerger to show partner.");
             Optional<BeanItem<Buerger>> opt = event.getItem();
             if (opt.isPresent()) {
-                LOG.error("Posting new QueryPartner");
                 Buerger entity = opt.get().getBean();
                 this.controller.postEvent(controller.buildAppEvent(EventType.QUERY_PARTNER).setEntity(entity));
             } else {

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/BuergerViewController.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/BuergerViewController.java
@@ -264,8 +264,15 @@ public class BuergerViewController implements Serializable, ControllerContext<Bu
 	 *
 	 * @param event
 	 */
-	private void releaseParent(Buerger event) {
-		//service.releaseElternteil(getCurrent().getBean(), event.getEntity());
+	private void releaseKind(Buerger event) {
+		Link link = current.getBean().getLink(Buerger.Rel.kinder.name());
+		List<Link> kinder = service.findAll(link)
+				.stream()
+				.map(Buerger::getId)
+				.filter(id -> !id.equals(event.getId()))
+				.collect(Collectors.toList());
+
+		service.setRelations(link, kinder);
 	}
 
 	/**
@@ -274,7 +281,14 @@ public class BuergerViewController implements Serializable, ControllerContext<Bu
 	 * @param event
 	 */
 	private void releasePartner(Buerger event) {
-		service.delete(event.getLink(Buerger.Rel.partner.name()));
+		Link link = current.getBean().getLink(Buerger.Rel.partner.name());
+		List<Link> partner = service.findAll(link)
+				.stream()
+				.map(Buerger::getId)
+				.filter(id -> !id.equals(event.getId()))
+				.collect(Collectors.toList());
+
+		service.setRelations(link, partner);
 	}
 
 
@@ -370,7 +384,7 @@ public class BuergerViewController implements Serializable, ControllerContext<Bu
 		registerToAppEvent(EventType.SAVE_PARTNER, this::savePartnerEventHandler);
 		registerToAppEvent(EventType.SAVE_AS_CHILD, this::saveAsChildEventHandler);
 		registerToAppEvent(EventType.ADD_SEARCHED_CHILD, this::addSearchedChildEventHandler);
-		registerToAppEvent(EventType.RELEASE_PARENT, this::releaseParentHandler);
+		registerToAppEvent(EventType.RELEASE_KIND, this::releaseKindHandler);
 		registerToAppEvent(EventType.RELEASE_PARTNER, this::releasePartnerHandler);
 		registerToAppEvent(EventType.SAVE_AS_PARTNER, this::saveAsPartnerEventHandler);
 		registerToAppEvent(EventType.ADD_PARTNER, this::addPartnerEventHandler);
@@ -406,10 +420,10 @@ public class BuergerViewController implements Serializable, ControllerContext<Bu
 		postEvent(buildComponentEvent(EventType.UPDATE_PARTNER).addEntity(event.getEntity()));
 	}
 
-	private void releaseParentHandler(Event<AppEvent<Buerger>> eventWrapper) {
+	private void releaseKindHandler(Event<AppEvent<Buerger>> eventWrapper) {
 		AppEvent<Buerger> event = eventWrapper.getData();
 		// Service Operationen ausführen
-		this.releaseParent(event.getEntity());
+		this.releaseKind(event.getEntity());
 		// UI Komponenten aktualisieren
 
 		GenericSuccessNotification succes = new GenericSuccessNotification(

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/factorys/BuergerViewFactory.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/factorys/BuergerViewFactory.java
@@ -12,16 +12,7 @@ import de.muenchen.vaadin.demo.i18nservice.buttons.TableAction;
 import de.muenchen.vaadin.demo.i18nservice.buttons.TableActionButton;
 import de.muenchen.vaadin.guilib.components.GenericConfirmationWindow;
 import de.muenchen.vaadin.guilib.components.GenericTable;
-import de.muenchen.vaadin.ui.components.BuergerChildTab;
-import de.muenchen.vaadin.ui.components.BuergerCreateForm;
-import de.muenchen.vaadin.ui.components.BuergerPartnerTab;
-import de.muenchen.vaadin.ui.components.BuergerReadForm;
-import de.muenchen.vaadin.ui.components.BuergerSearchTable;
-import de.muenchen.vaadin.ui.components.BuergerSelectTable;
-import de.muenchen.vaadin.ui.components.BuergerTable;
-import de.muenchen.vaadin.ui.components.BuergerUpdateForm;
-import de.muenchen.vaadin.ui.components.ChildTable;
-import de.muenchen.vaadin.ui.components.PartnerTable;
+import de.muenchen.vaadin.ui.components.*;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,7 +223,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<RefreshE
                 {
                     BeanItem<Buerger> item = container.getItem(id);
                     GenericConfirmationWindow win = new GenericConfirmationWindow(
-                            controller.buildAppEvent(EventType.RELEASE_PARENT).setItem(container.getItem(id)).setItemId(id),
+                            controller.buildAppEvent(EventType.RELEASE_KIND).setItem(container.getItem(id)).setItemId(id),
                             controller, SimpleAction.release);
                     controller.getNavigator().getUI().addWindow(win);
                     win.center();


### PR DESCRIPTION
## Beschreibung:

Kinder und Partner Relations werden jetzt korrekt entfernt.
## Branch-Checklist:
- [x] GUI getestet
## Bestätigungen:

nicht nötig
## Referenz:

closes #107 
