### PR TITLE
#95 hystrix

### DIFF
--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericConfirmationWindow.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericConfirmationWindow.java
@@ -12,7 +12,6 @@ import de.muenchen.vaadin.demo.i18nservice.buttons.Action;
  * Generisches Bestätigungsfenster mit einer "ok" und
  * einer "abbrechen" Schaltfläche.
  * <p/>
- * TODO -> sollte in einen generischen Artefakt übernommen werden.
  *
  * @author claus.straube
  */

--- a/I18nService/src/main/java/de/muenchen/vaadin/demo/i18nservice/buttons/SimpleAction.java
+++ b/I18nService/src/main/java/de/muenchen/vaadin/demo/i18nservice/buttons/SimpleAction.java
@@ -30,7 +30,7 @@ public enum SimpleAction implements Action {
     cancel,
     copy(FontAwesome.COPY, ShortcutAction.KeyCode.INSERT),
     add,
-    release(FontAwesome.TRASH_O),
+    association(FontAwesome.CHECK),
     logout(FontAwesome.SIGN_OUT);
     
 

--- a/vadin-demo-gui/pom.xml
+++ b/vadin-demo-gui/pom.xml
@@ -53,6 +53,42 @@
         </dependency>
         <!-- Other -->
 
+        <!-- Hystrix -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-hystrix</artifactId>
+            <version>${spring.cloud.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>om.netflix.archaius</groupId>
+                    <artifactId>archaius-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.netflix.archaius</groupId>
+            <artifactId>archaius-core</artifactId>
+            <version>0.7.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
+            <version>${spring.cloud.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>om.netflix.archaius</groupId>
+                    <artifactId>archaius-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-javanica</artifactId>
+            <version>1.4.16</version>
+        </dependency>
+
         <!-- vaadin -->
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vadin-demo-gui/pom.xml
+++ b/vadin-demo-gui/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <!-- Other -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.3</version>
+        </dependency>
 
         <!-- Hystrix -->
         <dependency>

--- a/vadin-demo-gui/pom.xml
+++ b/vadin-demo-gui/pom.xml
@@ -38,6 +38,11 @@
             <version>${spring.cloud.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-javanica</artifactId>
+            <version>1.4.16</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
             <version>${spring.cloud.version}</version>

--- a/vadin-demo-gui/pom.xml
+++ b/vadin-demo-gui/pom.xml
@@ -58,42 +58,6 @@
             <version>2.3</version>
         </dependency>
 
-        <!-- Hystrix -->
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-hystrix</artifactId>
-            <version>${spring.cloud.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>om.netflix.archaius</groupId>
-                    <artifactId>archaius-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.netflix.archaius</groupId>
-            <artifactId>archaius-core</artifactId>
-            <version>0.7.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
-            <version>${spring.cloud.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>om.netflix.archaius</groupId>
-                    <artifactId>archaius-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.netflix.hystrix</groupId>
-            <artifactId>hystrix-javanica</artifactId>
-            <version>1.4.16</version>
-        </dependency>
-
         <!-- vaadin -->
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vadin-demo-gui/pom.xml
+++ b/vadin-demo-gui/pom.xml
@@ -38,11 +38,6 @@
             <version>${spring.cloud.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.netflix.hystrix</groupId>
-            <artifactId>hystrix-javanica</artifactId>
-            <version>1.4.16</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
             <version>${spring.cloud.version}</version>

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/Application.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/Application.java
@@ -35,7 +35,6 @@ import org.springframework.web.filter.HiddenHttpMethodFilter;
 @Configuration
 @ComponentScan
 @EnableAutoConfiguration
-@EnableCircuitBreaker
 public class Application {
     
     public static void main(String[] args) throws Exception {

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/Application.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/Application.java
@@ -22,7 +22,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
-import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/Application.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/Application.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -34,6 +35,7 @@ import org.springframework.web.filter.HiddenHttpMethodFilter;
 @Configuration
 @ComponentScan
 @EnableAutoConfiguration
+@EnableCircuitBreaker
 public class Application {
     
     public static void main(String[] args) throws Exception {

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerFallbackDataGenerator.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerFallbackDataGenerator.java
@@ -1,0 +1,45 @@
+package de.muenchen.vaadin.services;
+
+import de.muenchen.vaadin.demo.api.local.Buerger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Created by claus.straube on 08.10.15.
+ * fabian.holtkoetter ist unschuldig.
+ */
+public class BuergerFallbackDataGenerator {
+
+    /** Fallback-Daten generierung. Diese Methoden werden durch Barrakuda mit dem gewünschten Verhalten befüllt. */
+
+    /**
+     * Generiert Fallback-Daten für Methoden die einen einzelnen Bürger zurückliefern.
+     *
+     * @return Generierter fallback-Wert.
+     */
+    public static Buerger createBuergerFallback() {
+        return null;
+    }
+
+    /**
+     * Generiert Fallback-Daten für Methoden die eine List von Bürgern zurückliefern.
+     *
+     * @return Generierter fallback-Wert.
+     */
+    public static List<Buerger> createBuergersFallback() {
+        return new ArrayList<>();
+    }
+
+    /**
+     * Generiert Fallback-Daten für Methoden die einen optionalen Bürger zurückliefern.
+     *
+     * @return Generierter fallback-Wert.
+     */
+    public static Optional<Buerger> createOptionalBuergerFallback() {
+        return Optional.empty();
+    }
+
+
+}

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerI18nResolver.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerI18nResolver.java
@@ -1,0 +1,65 @@
+package de.muenchen.vaadin.services;
+
+import com.vaadin.server.FontAwesome;
+import com.vaadin.spring.annotation.SpringComponent;
+import com.vaadin.spring.annotation.UIScope;
+import de.muenchen.vaadin.demo.i18nservice.I18nResolver;
+import de.muenchen.vaadin.guilib.services.MessageService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Created by claus.straube on 05.10.15.
+ * fabian.holtkoetter ist unschuldig.
+ */
+@SpringComponent
+@UIScope
+public class BuergerI18nResolver implements I18nResolver {
+
+    // TODO entweder hier oder im I18nServiceConfigImpl angeben
+    public static final String I18N_BASE_PATH = "buerger";
+    /** {@link MessageService} zur Auflösung der Platzhalter */
+    @Autowired
+    private MessageService msg;
+
+    /**
+     * Resolve the path (e.g. "asdf.label").
+     *
+     * @param path the path.
+     * @return the resolved String.
+     */
+    @Override
+    public String resolve(String path) {
+        return msg.get(path);
+    }
+
+    /**
+     * Resolve the relative path (e.g. "asdf.label").
+     * <p>
+     * The base path will be appended at start and then read from the properties.
+     *
+     * @param relativePath the path to add to the base path.
+     * @return the resolved String.
+     */
+    @Override
+    public String resolveRelative(String relativePath) {
+        return msg.get(I18N_BASE_PATH + "." + relativePath);
+    }
+
+    @Override
+    public String getBasePath() {
+        return I18N_BASE_PATH;
+    }
+
+    /**
+     * Resolve the relative path (e.g. ".asdf.label") to a icon.
+     * <p>
+     * The base path will be appended at start and then read from the properties.
+     *
+     * @param relativePath the path to add to the base path.
+     * @return the resolved String.
+     */
+    @Override
+    public FontAwesome resolveIcon(String relativePath) {
+        return msg.getFontAwesome(I18N_BASE_PATH + "." + relativePath + ".icon");
+    }
+}

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerService.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerService.java
@@ -19,8 +19,6 @@ public interface BuergerService {
 
     boolean delete(Link link);
 
-    Buerger copy(Link link);
-
     List<Buerger> findAll();
 
     List<Buerger> findAll(Link relation);

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerService.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerService.java
@@ -17,7 +17,7 @@ public interface BuergerService {
 
     Buerger update(Buerger buerger);
 
-    void delete(Link link);
+    boolean delete(Link link);
 
     Buerger copy(Link link);
 
@@ -29,7 +29,7 @@ public interface BuergerService {
 
     List<Buerger> queryBuerger(String query);
 
-    void setRelations(Link link, List<Link> relations);
+    boolean setRelations(Link link, List<Link> relations);
 
-    void setRelation(Link link, Link relation);
+    boolean setRelation(Link link, Link relation);
 }

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
@@ -58,9 +58,10 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             returnBuerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.create);
-        } catch (HttpClientErrorException e) {
+        } catch (ExecutionException e) {
+            HttpClientErrorException exception = (HttpClientErrorException) e.getCause();
             returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
-            LOG.error(e.getMessage());
+            LOG.error(exception.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create);
         } catch (TimeoutException e) {
             returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
@@ -83,9 +84,10 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             returnBuerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.update);
-        } catch (HttpClientErrorException e) {
+        } catch (ExecutionException e) {
+            HttpClientErrorException exception = (HttpClientErrorException) e.getCause();
             returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
-            LOG.error(e.getMessage());
+            LOG.error(exception.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update);
         } catch (TimeoutException e) {
             returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
@@ -108,9 +110,10 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.delete);
             return true;
-        } catch (HttpClientErrorException e) {
+        } catch (ExecutionException e) {
+            HttpClientErrorException exception = (HttpClientErrorException) e.getCause();
             LOG.error(e.getMessage());
-            HttpStatus statusCode = e.getStatusCode();
+            HttpStatus statusCode = exception.getStatusCode();
             if (statusCode.equals(HttpStatus.CONFLICT) || statusCode.equals(HttpStatus.NOT_FOUND))
                 showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.delete, statusCode.toString());
             else
@@ -136,9 +139,10 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             return buergers;
-        } catch (HttpClientErrorException e) {
+        } catch (ExecutionException e) {
+            HttpClientErrorException exception = (HttpClientErrorException) e.getCause();
             buergers = BuergerFallbackDataGenerator.createBuergersFallback();
-            LOG.error(e.getMessage());
+            LOG.error(exception.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
             buergers = BuergerFallbackDataGenerator.createBuergersFallback();
@@ -160,9 +164,10 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         Future<List<Buerger>> result = Executors.newCachedThreadPool().submit(() -> client.findAll(relation));
         try {
             buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
-        } catch (HttpClientErrorException e) {
+        } catch (ExecutionException e) {
+            HttpClientErrorException exception = (HttpClientErrorException) e.getCause();
             buergers = BuergerFallbackDataGenerator.createBuergersFallback();
-            LOG.error(e.getMessage());
+            LOG.error(exception.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
             buergers = BuergerFallbackDataGenerator.createBuergersFallback();
@@ -184,9 +189,10 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         Future<Optional<Buerger>> result = Executors.newCachedThreadPool().submit(() -> client.findOne(link));
         try {
             buerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
-        } catch (HttpClientErrorException e) {
+        } catch (ExecutionException e) {
+            HttpClientErrorException exception = (HttpClientErrorException) e.getCause();
             buerger = BuergerFallbackDataGenerator.createOptionalBuergerFallback();
-            LOG.error(e.getMessage());
+            LOG.error(exception.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
             buerger = BuergerFallbackDataGenerator.createOptionalBuergerFallback();

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
@@ -59,15 +59,15 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             returnBuerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.create);
         } catch (HttpClientErrorException e) {
-            returnBuerger = this.createBuergerFallback();
+            returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create);
         } catch (TimeoutException e) {
-            returnBuerger = this.createBuergerFallback();
+            returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create, TIMEOUT_I18N);
         } catch (Exception e) {
-            returnBuerger = this.createBuergerFallback();
+            returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create);
         } finally {
@@ -84,15 +84,15 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             returnBuerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.update);
         } catch (HttpClientErrorException e) {
-            returnBuerger = this.createBuergerFallback();
+            returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update);
         } catch (TimeoutException e) {
-            returnBuerger = this.createBuergerFallback();
+            returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update, TIMEOUT_I18N);
         } catch (Exception e) {
-            returnBuerger = this.createBuergerFallback();
+            returnBuerger = BuergerFallbackDataGenerator.createBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update);
         } finally {
@@ -137,15 +137,15 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             return buergers;
         } catch (HttpClientErrorException e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
@@ -161,15 +161,15 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
         } catch (HttpClientErrorException e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
@@ -185,15 +185,15 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             buerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
         } catch (HttpClientErrorException e) {
-            buerger = this.createOptionalBuergerFallback();
+            buerger = BuergerFallbackDataGenerator.createOptionalBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
-            buerger = this.createOptionalBuergerFallback();
+            buerger = BuergerFallbackDataGenerator.createOptionalBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
-            buerger = this.createOptionalBuergerFallback();
+            buerger = BuergerFallbackDataGenerator.createOptionalBuergerFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
@@ -215,7 +215,7 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             buergers = new ArrayList<>();
 //            buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
         } catch (HttpClientErrorException e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
 //        } catch (TimeoutException e){
@@ -223,7 +223,7 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
 //            LOG.error(e.getMessage());
 //            showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
-            buergers = this.createBuergersFallback();
+            buergers = BuergerFallbackDataGenerator.createBuergersFallback();
             LOG.error(e.getMessage());
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
@@ -278,35 +278,6 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         } finally {
             result.cancel(true);
         }
-    }
-
-    /** Fallback-Daten generierung. Diese Methoden werden durch Barrakuda mit dem gewünschten Verhalten befüllt. */
-
-    /**
-     * Generiert Fallback-Daten für Methoden die einen einzelnen Bürger zurückliefern.
-     *
-     * @return Generierter fallback-Wert.
-     */
-    private Buerger createBuergerFallback() {
-        return null;
-    }
-
-    /**
-     * Generiert Fallback-Daten für Methoden die eine List von Bürgern zurückliefern.
-     *
-     * @return Generierter fallback-Wert.
-     */
-    private List<Buerger> createBuergersFallback() {
-        return new ArrayList<>();
-    }
-
-    /**
-     * Generiert Fallback-Daten für Methoden die einen optionalen Bürger zurückliefern.
-     *
-     * @return Generierter fallback-Wert.
-     */
-    private Optional<Buerger> createOptionalBuergerFallback() {
-        return Optional.empty();
     }
 
     /**

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
@@ -59,16 +59,16 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             returnBuerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.create);
         } catch (HttpClientErrorException e) {
+            returnBuerger = this.createBuergerFallback();
             LOG.error(e.getMessage());
-            returnBuerger = null;
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create);
         } catch (TimeoutException e) {
+            returnBuerger = this.createBuergerFallback();
             LOG.error(e.getMessage());
-            returnBuerger = null;
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create, TIMEOUT_I18N);
         } catch (Exception e) {
+            returnBuerger = this.createBuergerFallback();
             LOG.error(e.getMessage());
-            returnBuerger = null;
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create);
         } finally {
             result.cancel(true);
@@ -84,16 +84,16 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             returnBuerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.update);
         } catch (HttpClientErrorException e) {
+            returnBuerger = this.createBuergerFallback();
             LOG.error(e.getMessage());
-            returnBuerger = null;
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update);
         } catch (TimeoutException e) {
+            returnBuerger = this.createBuergerFallback();
             LOG.error(e.getMessage());
-            returnBuerger = null;
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update, TIMEOUT_I18N);
         } catch (Exception e) {
+            returnBuerger = this.createBuergerFallback();
             LOG.error(e.getMessage());
-            returnBuerger = null;
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update);
         } finally {
             result.cancel(true);
@@ -137,16 +137,16 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
             return buergers;
         } catch (HttpClientErrorException e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
             result.cancel(true);
@@ -161,16 +161,16 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
         } catch (HttpClientErrorException e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
             result.cancel(true);
@@ -185,16 +185,16 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         try {
             buerger = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
         } catch (HttpClientErrorException e) {
+            buerger = this.createOptionalBuergerFallback();
             LOG.error(e.getMessage());
-            buerger = Optional.empty();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } catch (TimeoutException e) {
+            buerger = this.createOptionalBuergerFallback();
             LOG.error(e.getMessage());
-            buerger = Optional.empty();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
+            buerger = this.createOptionalBuergerFallback();
             LOG.error(e.getMessage());
-            buerger = Optional.empty();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
             result.cancel(true);
@@ -215,16 +215,16 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
             buergers = new ArrayList<>();
 //            buergers = result.get(TIMEOUT_VAL, TimeUnit.SECONDS);
         } catch (HttpClientErrorException e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
 //        } catch (TimeoutException e){
+//            buergers = this.createBuergersFallback();
 //            LOG.error(e.getMessage());
-//            buergers = new ArrayList<>();
 //            showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read, TIMEOUT_I18N);
         } catch (Exception e) {
+            buergers = this.createBuergersFallback();
             LOG.error(e.getMessage());
-            buergers = new ArrayList<>();
             showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
         } finally {
 //            result.cancel(true);
@@ -278,6 +278,35 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         } finally {
             result.cancel(true);
         }
+    }
+
+    /** Fallback-Daten generierung. Diese Methoden werden durch Barrakuda mit dem gewünschten Verhalten befüllt. */
+
+    /**
+     * Generiert Fallback-Daten für Methoden die einen einzelnen Bürger zurückliefern.
+     *
+     * @return Generierter fallback-Wert.
+     */
+    private Buerger createBuergerFallback() {
+        return null;
+    }
+
+    /**
+     * Generiert Fallback-Daten für Methoden die eine List von Bürgern zurückliefern.
+     *
+     * @return Generierter fallback-Wert.
+     */
+    private List<Buerger> createBuergersFallback() {
+        return new ArrayList<>();
+    }
+
+    /**
+     * Generiert Fallback-Daten für Methoden die einen optionalen Bürger zurückliefern.
+     *
+     * @return Generierter fallback-Wert.
+     */
+    private Optional<Buerger> createOptionalBuergerFallback() {
+        return Optional.empty();
     }
 
     /**

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/services/BuergerServiceImpl.java
@@ -1,11 +1,20 @@
 package de.muenchen.vaadin.services;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import com.netflix.hystrix.contrib.javanica.aop.aspectj.HystrixCommandAspect;
+import com.netflix.hystrix.contrib.javanica.command.HystrixCommandBuilder;
+import com.netflix.hystrix.contrib.javanica.command.HystrixCommandFactory;
+import com.vaadin.server.Page;
 import com.vaadin.spring.annotation.SpringComponent;
 import com.vaadin.spring.annotation.UIScope;
 import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.demo.api.rest.BuergerRestClient;
 import de.muenchen.vaadin.demo.api.rest.BuergerRestClientImpl;
 import de.muenchen.vaadin.demo.apilib.services.SecurityService;
+import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
+import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
+import de.muenchen.vaadin.guilib.components.GenericErrorNotification;
+import de.muenchen.vaadin.guilib.components.GenericSuccessNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,47 +22,59 @@ import org.springframework.hateoas.Link;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.Serializable;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getNotificationPath;
+
 /**
- *
  * @author claus.straube
  */
-@SpringComponent @UIScope
-public class BuergerServiceImpl implements BuergerService, Serializable {
+@SpringComponent
+@UIScope
+public class BuergerServiceImpl implements BuergerService, Serializable{
 
     private static final Logger LOG = LoggerFactory.getLogger(BuergerService.class);
-    
+
     private BuergerRestClient client;
     private RestTemplate template;
     private SecurityService securityService;
+    private BuergerI18nResolver resolver;
 
     @Autowired
-    public BuergerServiceImpl(InfoService infoService, SecurityService securityService) {
-        this.securityService=securityService;
-
+    public BuergerServiceImpl(InfoService infoService, SecurityService securityService, BuergerI18nResolver resolver) {
+        this.securityService = securityService;
         //TODO
         this.client = new BuergerRestClientImpl(getTemplate(), infoService.getBaseUri());
+        this.resolver = resolver;
     }
 
+    @HystrixCommand(fallbackMethod = "createFallback")
     @Override
     public Buerger create(Buerger buerger) {
-        return client.create(buerger);
+        final Buerger buerger1 = client.create(buerger);
+        showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.create);
+        return buerger1;
     }
 
+    @HystrixCommand(fallbackMethod = "updateFallback")
     @Override
     public Buerger update(Buerger buerger) {
-        return client.update(buerger);
+        final Buerger buerger1 = client.update(buerger);
+        showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.update);
+        return buerger1;
     }
 
+    @HystrixCommand(fallbackMethod = "deleteFallback")
     @Override
-    public void delete(Link link) {
+    public boolean delete(Link link) {
         client.delete(link);
+        showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.delete);
+        return true;
     }
 
+    @HystrixCommand(fallbackMethod = "copyFallback")
     @Override
     public Buerger copy(Link link) {
         Optional<Buerger> original = findOne(link);
@@ -63,21 +84,25 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         return create(original.get());
     }
 
+    @HystrixCommand(fallbackMethod = "findAllFallback")
     @Override
     public List<Buerger> findAll() {
         return client.findAll();
     }
 
+    @HystrixCommand(fallbackMethod = "findAllFallback")
     @Override
     public List<Buerger> findAll(Link relation) {
         return client.findAll(relation);
     }
 
+    @HystrixCommand(fallbackMethod = "findOneFallback")
     @Override
     public Optional<Buerger> findOne(Link link) {
         return client.findOne(link);
     }
 
+    @HystrixCommand(fallbackMethod = "queryFallback")
     @Override
     public List<Buerger> queryBuerger(String query) {
         //    Link link = this.infoService.getUrl("buerger_query");
@@ -86,18 +111,26 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         return new ArrayList<>();
     }
 
+
+    @HystrixCommand(fallbackMethod = "setRelationsFallback")
     @Override
-    public void setRelations(Link link, List<Link> links) {
+    public boolean setRelations(Link link, List<Link> links) {
         client.setRelations(link, links);
+        showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.association);
+        return true;
     }
 
+    @HystrixCommand(fallbackMethod = "setRelationFallback")
     @Override
-    public void setRelation(Link link, Link relation) {
+    public boolean setRelation(Link link, Link relation) {
         client.setRelation(link, relation);
+        showSuccessNotification(I18nPaths.NotificationType.success, SimpleAction.association);
+        return true;
     }
 
     /**
      * Gets the resttemplate from the security if not present
+     *
      * @return resttemplate of this session
      */
     public RestTemplate getTemplate() {
@@ -106,5 +139,70 @@ public class BuergerServiceImpl implements BuergerService, Serializable {
         }
         return securityService.getRestTemplate().orElse(null);
     }
-  
+
+    //////////////////////
+    // Fallback Methods //
+    //////////////////////
+
+    public Buerger createFallback(Buerger buerger) {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.create);
+        return null;
+    }
+
+    public Buerger updateFallback(Buerger buerger) {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.update);
+        return null;
+    }
+
+    public boolean deleteFallback(Link link) {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.delete);
+        return false;
+    }
+
+    public Buerger copyFallback(Link link) {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.copy);
+        return null;
+    }
+
+    public List<Buerger> findAllFallback() {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
+        return new ArrayList<>();
+    }
+
+    public List<Buerger> findAllFallback(Link relation) {
+        return findAllFallback();
+    }
+
+    public Optional<Buerger> findOneFallback(Link link) {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.read);
+        return Optional.empty();
+    }
+
+    public List<Buerger> queryFallback(Link link) {
+        return findAllFallback();
+    }
+
+    public boolean setRelationsFallback(Link link, List<Link> links){
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.association);
+        return false;
+    }
+
+    public boolean setRelationFallback(Link link, Link relation) {
+        showErrorNotification(I18nPaths.NotificationType.error, SimpleAction.association);
+        return false;
+    }
+
+    private void showSuccessNotification(I18nPaths.NotificationType type, SimpleAction action) {
+        GenericSuccessNotification succes = new GenericSuccessNotification(
+                resolver.resolveRelative(getNotificationPath(type, action, I18nPaths.Type.label)),
+                resolver.resolveRelative(getNotificationPath(type, action, I18nPaths.Type.text)));
+        succes.show(Page.getCurrent());
+    }
+
+    private void showErrorNotification(I18nPaths.NotificationType type, SimpleAction action) {
+        GenericErrorNotification succes = new GenericErrorNotification(
+                resolver.resolveRelative(getNotificationPath(type, action, I18nPaths.Type.label)),
+                resolver.resolveRelative(getNotificationPath(type, action, I18nPaths.Type.text)));
+        succes.show(Page.getCurrent());
+    }
 }

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerCreateChildView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerCreateChildView.java
@@ -2,6 +2,7 @@ package de.muenchen.vaadin.ui.app.views;
 
 import com.vaadin.spring.annotation.SpringView;
 import com.vaadin.spring.annotation.UIScope;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
@@ -20,8 +21,8 @@ public class BuergerCreateChildView extends DefaultBuergerView {
     protected static final Logger LOG = LoggerFactory.getLogger(BuergerCreateChildView.class);
 
     @Autowired
-    public BuergerCreateChildView(BuergerViewController controller, MainUI ui) {
-        super(controller, ui);
+    public BuergerCreateChildView(BuergerViewController controller, BuergerI18nResolver resolver, MainUI ui) {
+        super(controller, resolver, ui);
         LOG.debug("creating 'buerger_create_child_view'");
     }
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerCreatePartnerView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerCreatePartnerView.java
@@ -2,6 +2,7 @@ package de.muenchen.vaadin.ui.app.views;
 
 import com.vaadin.spring.annotation.SpringView;
 import com.vaadin.spring.annotation.UIScope;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
@@ -20,8 +21,8 @@ public class BuergerCreatePartnerView extends DefaultBuergerView {
     protected static final Logger LOG = LoggerFactory.getLogger(BuergerCreatePartnerView.class);
 
     @Autowired
-    public BuergerCreatePartnerView(BuergerViewController controller, MainUI ui) {
-        super(controller, ui);
+    public BuergerCreatePartnerView(BuergerViewController controller, BuergerI18nResolver resolver, MainUI ui) {
+        super(controller, resolver, ui);
         LOG.debug("creating 'buerger_create_partner_view'");
     }
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerCreateView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerCreateView.java
@@ -2,6 +2,7 @@ package de.muenchen.vaadin.ui.app.views;
 
 import com.vaadin.spring.annotation.SpringView;
 import com.vaadin.spring.annotation.UIScope;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
@@ -20,8 +21,8 @@ public class BuergerCreateView extends DefaultBuergerView {
     protected static final Logger LOG = LoggerFactory.getLogger(BuergerCreateView.class);
 
     @Autowired
-    public BuergerCreateView(BuergerViewController controller, MainUI ui) {
-        super(controller, ui);
+    public BuergerCreateView(BuergerViewController controller, BuergerI18nResolver resolver, MainUI ui) {
+        super(controller, resolver, ui);
         LOG.debug("creating 'buerger_create_view'");
     }
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerDetailView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerDetailView.java
@@ -7,6 +7,8 @@ import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
+import de.muenchen.vaadin.demo.i18nservice.I18nResolver;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.components.BuergerChildTab;
 import de.muenchen.vaadin.ui.components.BuergerPartnerTab;
@@ -32,8 +34,8 @@ public class BuergerDetailView extends DefaultBuergerView {
     private BuergerPartnerTab partnerTab;
     private BuergerReadForm readForm;
     @Autowired
-    public BuergerDetailView(BuergerViewController controller, MainUI ui) {
-        super(controller, ui);
+    public BuergerDetailView(BuergerViewController controller, BuergerI18nResolver resolver, MainUI ui) {
+        super(controller, resolver, ui);
         LOG.debug("creating 'buerger_read_view'");
     }
 
@@ -53,12 +55,12 @@ public class BuergerDetailView extends DefaultBuergerView {
         // add kind tab
         childTab = controller.getViewFactory().generateChildTab(BuergerDetailView.NAME, BuergerCreateChildView.NAME, BuergerTableView.NAME);
         TabSheet.Tab kindTab = tabSheet.addTab(childTab);
-        kindTab.setCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Rel.kinder.name(), I18nPaths.Type.label)));
+        kindTab.setCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Rel.kinder.name(), I18nPaths.Type.label)));
 
 
         partnerTab = controller.getViewFactory().generatePartnerTab(BuergerDetailView.NAME, BuergerCreatePartnerView.NAME, null, NAME);
         TabSheet.Tab pTab = tabSheet.addTab(partnerTab);
-        pTab.setCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Rel.partner.name(), I18nPaths.Type.label)));
+        pTab.setCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Rel.partner.name(), I18nPaths.Type.label)));
         layout.addComponent(tabSheet);
         
         addComponent(layout);

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerTableView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerTableView.java
@@ -2,6 +2,7 @@ package de.muenchen.vaadin.ui.app.views;
 
 import com.vaadin.spring.annotation.SpringView;
 import com.vaadin.spring.annotation.UIScope;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.components.BuergerGrid;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
@@ -23,8 +24,8 @@ public class BuergerTableView extends DefaultBuergerView {
     private BuergerGrid grid;
 
     @Autowired
-    public BuergerTableView(BuergerViewController controller, MainUI ui) {
-        super(controller, ui);
+    public BuergerTableView(BuergerViewController controller, BuergerI18nResolver resolver, MainUI ui) {
+        super(controller, resolver, ui);
         LOG.debug("creating 'buerger_table_view'");
         
     }

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerUpdateView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/BuergerUpdateView.java
@@ -2,6 +2,7 @@ package de.muenchen.vaadin.ui.app.views;
 
 import com.vaadin.spring.annotation.SpringView;
 import com.vaadin.spring.annotation.UIScope;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.components.BuergerUpdateForm;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
@@ -23,8 +24,8 @@ public class BuergerUpdateView extends DefaultBuergerView {
     private BuergerUpdateForm form;
 
     @Autowired
-    public BuergerUpdateView(BuergerViewController controller, EventBus eventbus, MainUI ui) {
-        super(controller, ui);
+    public BuergerUpdateView(BuergerViewController controller, BuergerI18nResolver resolver, EventBus eventbus, MainUI ui) {
+        super(controller, resolver, ui);
         LOG.debug("creating 'buerger_update_view'");
     }
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/DefaultBuergerView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/DefaultBuergerView.java
@@ -6,6 +6,7 @@ import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.MainUI;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
@@ -24,9 +25,11 @@ import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getPagePath;
 public abstract class DefaultBuergerView extends VerticalLayout implements View{
 
     BuergerViewController controller;
+    BuergerI18nResolver resolver;
     
-    public DefaultBuergerView(BuergerViewController controller, MainUI ui) {
+    public DefaultBuergerView(BuergerViewController controller, BuergerI18nResolver resolver, MainUI ui) {
         this.controller = controller;
+        this.resolver = resolver;
         this.controller.registerUI(ui);
     }
     
@@ -47,7 +50,7 @@ public abstract class DefaultBuergerView extends VerticalLayout implements View{
     protected void addHeadline() {
         
         // headline
-        Label pageTitle = new Label(controller.resolveRelative(getPagePath(Type.title)));
+        Label pageTitle = new Label(resolver.resolveRelative(getPagePath(Type.title)));
         pageTitle.addStyleName(ValoTheme.LABEL_H1);
         pageTitle.addStyleName(ValoTheme.LABEL_COLORED);
         

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/DefaultBuergerView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/DefaultBuergerView.java
@@ -33,15 +33,6 @@ public abstract class DefaultBuergerView extends VerticalLayout implements View{
         this.controller.registerUI(ui);
     }
     
-    
-    /**
-     * 
-     */
-    @PostConstruct
-    private void postConstruct() {
-        //TODO Wirklich notwendig? Lieber enter() verwenden?
-    }
-    
     /**
      * 
      */

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/LoginView.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/LoginView.java
@@ -16,7 +16,7 @@ import de.muenchen.eventbus.selector.Key;
 import de.muenchen.vaadin.demo.apilib.services.SecurityService;
 import de.muenchen.vaadin.guilib.components.GenericNotification;
 import de.muenchen.vaadin.guilib.components.GenericWarningNotification;
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import reactor.bus.EventBus;
@@ -37,7 +37,7 @@ public class LoginView extends VerticalLayout implements View {
 
     @Autowired
     public LoginView(SecurityService security, Environment env) {
-        websiteName = WordUtils.capitalize(env.getProperty("spring.application.name"));
+        websiteName = StringUtils.capitalize(env.getProperty("spring.application.name"));
         this.security = security;
         setSizeFull();
         Component loginForm = buildLoginForm();

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/TableSelectWindow.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/app/views/TableSelectWindow.java
@@ -3,6 +3,7 @@ package de.muenchen.vaadin.ui.app.views;
 import com.vaadin.spring.annotation.UIScope;
 import com.vaadin.ui.AbstractComponent;
 import com.vaadin.ui.Window;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,9 +19,9 @@ public class TableSelectWindow extends Window {
     protected static final Logger LOG = LoggerFactory.getLogger(TableSelectWindow.class);
 
 
-    public TableSelectWindow(BuergerViewController controller, AbstractComponent table) {
+    public TableSelectWindow(BuergerViewController controller, BuergerI18nResolver resolver, AbstractComponent table) {
 
-        super(controller.resolveRelative("form.add.headline.label"), table);
+        super(resolver.resolveRelative("form.add.headline.label"), table);
 
         center();
         setModal(true);

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerChildTab.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerChildTab.java
@@ -10,6 +10,7 @@ import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
 import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.views.TableSelectWindow;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
@@ -24,20 +25,20 @@ public class BuergerChildTab extends CustomComponent {
     private GenericGrid grid;
     private ActionButton delete;
 
-    public BuergerChildTab(BuergerViewController controller, String navigateToForDetail, String navigateToForCreate, String navigateBack) {
+    public BuergerChildTab(BuergerViewController controller, BuergerI18nResolver resolver, String navigateToForDetail, String navigateToForCreate, String navigateBack) {
 
         this.controller = controller;
 
-        ActionButton create = new ActionButton(controller, SimpleAction.create, navigateToForCreate);
+        ActionButton create = new ActionButton(resolver, SimpleAction.create, navigateToForCreate);
         create.addClickListener(clickEvent -> {
             controller.getNavigator().navigateTo(navigateToForCreate);
         });
-        ActionButton add = new ActionButton(controller, SimpleAction.add, "");
+        ActionButton add = new ActionButton(resolver, SimpleAction.add, "");
         add.addClickListener(clickEvent -> {
-            getUI().addWindow(new TableSelectWindow(controller, controller.getViewFactory().generateChildSearchTable()));
+            getUI().addWindow(new TableSelectWindow(controller, resolver, controller.getViewFactory().generateChildSearchTable()));
         });
 
-        delete = new ActionButton(controller, SimpleAction.delete, null);
+        delete = new ActionButton(resolver, SimpleAction.delete, null);
         delete.addClickListener(clickEvent -> {
             if (grid.getSelectedRows() != null) {
                 for (Object next : grid.getSelectedRows()) {
@@ -56,10 +57,10 @@ public class BuergerChildTab extends CustomComponent {
         grid.addSelectionListener(selectionEvent -> setButtonVisability());
 
         // set headers
-        this.grid.getColumn(Buerger.Field.vorname.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.geburtsdatum.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.nachname.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.augenfarbe.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.vorname.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.geburtsdatum.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.nachname.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.augenfarbe.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), I18nPaths.Type.column_header)));
 
         // Layout für die Schaltflächen über der Tabelle
         HorizontalLayout hlayout = new HorizontalLayout(create, add, delete);
@@ -69,7 +70,7 @@ public class BuergerChildTab extends CustomComponent {
         vlayout.setSpacing(true);
         vlayout.setMargin(true);
 
-        setId(String.format("%s_%s_%s_CHILD_TAB", navigateToForDetail, navigateBack, BuergerViewController.I18N_BASE_PATH));
+        setId(String.format("%s_%s_%s_CHILD_TAB", navigateToForDetail, navigateBack, BuergerI18nResolver.I18N_BASE_PATH));
         setCompositionRoot(vlayout);
     }
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerCreateForm.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerCreateForm.java
@@ -19,6 +19,7 @@ import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
 import de.muenchen.vaadin.guilib.components.GenericWarningNotification;
 import de.muenchen.vaadin.guilib.util.ValidatorFactory;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
 import java.util.Optional;
@@ -35,6 +36,7 @@ public class BuergerCreateForm extends CustomComponent {
     private final String navigateTo;
     private final String back;
     private final BuergerViewController controller;
+    private final BuergerI18nResolver resolver;
     private Optional<String> relation;
 
     /**
@@ -46,8 +48,8 @@ public class BuergerCreateForm extends CustomComponent {
      * @param controller der Entity Controller
      * @param navigateTo Zielseite nach Druck der 'erstellen' Schaltfläche
      */
-    public BuergerCreateForm(final BuergerViewController controller, final String navigateTo, String relation) {
-        this(controller, navigateTo, relation, navigateTo);
+    public BuergerCreateForm(final BuergerViewController controller, BuergerI18nResolver resolver, final String navigateTo, String relation) {
+        this(controller, resolver, navigateTo, relation, navigateTo);
         this.createForm();
     }
     
@@ -61,10 +63,11 @@ public class BuergerCreateForm extends CustomComponent {
      * @param navigateTo Zielseite nach Druck der 'erstellen' Schaltfläche
      * @param back Zielseite nach Druck der 'abbrechen' Schaltfläche
      */
-    public BuergerCreateForm(final BuergerViewController controller, final String navigateTo, String relation, String back) {
+    public BuergerCreateForm(final BuergerViewController controller, BuergerI18nResolver resolver, final String navigateTo, String relation, String back) {
         this.navigateTo = navigateTo;
         this.back = back;
         this.controller = controller;
+        this.resolver = resolver;
         this.relation = Optional.ofNullable(relation);
         this.createForm();
     }
@@ -73,14 +76,14 @@ public class BuergerCreateForm extends CustomComponent {
      * Erzeugt das eigentliche Formular.
      */
     private void createForm() {
-        Validator val = ValidatorFactory.getValidator(ValidatorFactory.Type.NULL, controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), "false");
+        Validator val = ValidatorFactory.getValidator(ValidatorFactory.Type.NULL, resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), "false");
         FormLayout layout = new FormLayout();
         HorizontalLayout buttonLayout = new HorizontalLayout();
         buttonLayout.setSpacing(true);
         layout.setMargin(true);
         
         // headline
-        Label headline = new Label(controller.resolveRelative(
+        Label headline = new Label(resolver.resolveRelative(
                 getFormPath(SimpleAction.create,
                         I18nPaths.Component.headline,
                         Type.label)));
@@ -93,9 +96,9 @@ public class BuergerCreateForm extends CustomComponent {
         
         // Fokus auf das erste Feld setzen
         TextField firstField = controller.getUtil().createFormTextField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.label)),
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.input_prompt)),
-                Buerger.Field.vorname.name(), BuergerViewController.I18N_BASE_PATH);
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.input_prompt)),
+                Buerger.Field.vorname.name(), BuergerI18nResolver.I18N_BASE_PATH);
         firstField.focus();
         String abc = "";
         for(char c = 'a';c <= 'z'; c++)
@@ -108,37 +111,37 @@ public class BuergerCreateForm extends CustomComponent {
             abc+=Character.toString((char)i);
         abc+="-";
 
-        Validator val0 = ValidatorFactory.getValidator(ValidatorFactory.Type.REGEXP, controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validationstring)), "true", "[" + abc + "]*");
+        Validator val0 = ValidatorFactory.getValidator(ValidatorFactory.Type.REGEXP, resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validationstring)), "true", "[" + abc + "]*");
 
-        Validator val1 = ValidatorFactory.getValidator(ValidatorFactory.Type.STRING_LENGTH, controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), 1 + "", "" + Integer.MAX_VALUE, "true");
+        Validator val1 = ValidatorFactory.getValidator(ValidatorFactory.Type.STRING_LENGTH, resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), 1 + "", "" + Integer.MAX_VALUE, "true");
         firstField.addValidator(val0);
         firstField.addValidator(val1);
         layout.addComponent(firstField);
         
         // alle anderen Felder
         TextField secField = controller.getUtil().createFormTextField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.label)),
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.input_prompt)),
-                Buerger.Field.nachname.name(), BuergerViewController.I18N_BASE_PATH);
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.input_prompt)),
+                Buerger.Field.nachname.name(), BuergerI18nResolver.I18N_BASE_PATH);
         secField.addValidator(val1);
         secField.addValidator(val0);
         layout.addComponent(secField);
         ComboBox eyecolorSelector = controller.getUtil().createFormComboBox(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), Type.label)),
                 Buerger.Field.augenfarbe.name(),
                 Augenfarbe.class);
         layout.addComponent(eyecolorSelector);
         DateField birthdayfield = controller.getUtil().createFormDateField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.label)),
-                Buerger.Field.geburtsdatum.name(), BuergerViewController.I18N_BASE_PATH);
-        String errorMsg = controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.validation));
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.label)),
+                Buerger.Field.geburtsdatum.name(), BuergerI18nResolver.I18N_BASE_PATH);
+        String errorMsg = resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.validation));
         Validator val3 = ValidatorFactory.getValidator(ValidatorFactory.Type.DATE_RANGE, errorMsg, "start", null);
         birthdayfield.addValidator(val3);
         layout.addComponent(birthdayfield);    
 
         layout.addComponent(buttonLayout);
         // die 'speichern' Schaltfläche
-        String createLabel = controller.resolveRelative(
+        String createLabel = resolver.resolveRelative(
                 getFormPath(SimpleAction.create,
                         I18nPaths.Component.button,
                         Type.label));
@@ -175,8 +178,8 @@ public class BuergerCreateForm extends CustomComponent {
                 binder.setItemDataSource(new Buerger());
             } catch (CommitException | Validator.InvalidValueException e) {
                 GenericWarningNotification warn = new GenericWarningNotification(
-                        controller.resolveRelative(getNotificationPath(NotificationType.warning, SimpleAction.save, Type.label)),
-                        controller.resolveRelative(getNotificationPath(NotificationType.warning, SimpleAction.save, Type.text)));
+                        resolver.resolveRelative(getNotificationPath(NotificationType.warning, SimpleAction.save, Type.label)),
+                        resolver.resolveRelative(getNotificationPath(NotificationType.warning, SimpleAction.save, Type.text)));
                 warn.show(Page.getCurrent());
             }
         });
@@ -186,7 +189,7 @@ public class BuergerCreateForm extends CustomComponent {
         buttonLayout.addComponent(createButton);
         // die 'abbrechen' Schaltfläche
 
-        ActionButton back = new ActionButton(controller, SimpleAction.back, "lsadf");
+        ActionButton back = new ActionButton(resolver, SimpleAction.back, "lsadf");
         back.addClickListener(clickEvent -> getNavigator().navigateTo(getNavigateBack()));
         buttonLayout.addComponent(back);
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerGrid.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerGrid.java
@@ -10,6 +10,7 @@ import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
 import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.views.BuergerCreateView;
 import de.muenchen.vaadin.ui.app.views.BuergerDetailView;
 import de.muenchen.vaadin.ui.app.views.BuergerUpdateView;
@@ -26,7 +27,8 @@ import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getEntityFieldPath;
 public class BuergerGrid extends CustomComponent {
 
     protected static final Logger LOG = LoggerFactory.getLogger(BuergerGrid.class);
-    private BuergerViewController controller;
+    private final BuergerViewController controller;
+    private final BuergerI18nResolver resolver;
 
     private GenericGrid grid;
     private TextField filter = new TextField();
@@ -37,9 +39,10 @@ public class BuergerGrid extends CustomComponent {
     private ActionButton delete;
     private ActionButton create;
 
-    public BuergerGrid(final BuergerViewController controller) {
+    public BuergerGrid(final BuergerViewController controller, final BuergerI18nResolver resolver) {
 
         this.controller = controller;
+        this.resolver = resolver;
 
         VerticalLayout layout = new VerticalLayout();
         this.grid = controller.getViewFactory().generateGrid();
@@ -114,16 +117,16 @@ public class BuergerGrid extends CustomComponent {
         });
 
         // set headers
-        this.grid.getColumn(Buerger.Field.vorname.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.geburtsdatum.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.nachname.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.augenfarbe.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.vorname.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.geburtsdatum.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.nachname.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.augenfarbe.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), I18nPaths.Type.column_header)));
 
         setCompositionRoot(layout);
     }
 
     private void createCopy() {
-        copy = new ActionButton(controller, SimpleAction.copy, null);
+        copy = new ActionButton(resolver, SimpleAction.copy, null);
         copy.addClickListener(clickEvent -> {
             LOG.debug("copying selected items");
             if (grid.getSelectedRows() != null) {
@@ -138,7 +141,7 @@ public class BuergerGrid extends CustomComponent {
     }
 
     private void createDelete() {
-        delete = new ActionButton(controller, SimpleAction.delete, null);
+        delete = new ActionButton(resolver, SimpleAction.delete, null);
         delete.addClickListener(clickEvent -> {
             LOG.debug("deleting selected items");
             if (grid.getSelectedRows() != null) {
@@ -152,7 +155,7 @@ public class BuergerGrid extends CustomComponent {
     }
 
     private void createEdit() {
-        edit = new ActionButton(controller, SimpleAction.update, BuergerUpdateView.NAME);
+        edit = new ActionButton(resolver, SimpleAction.update, BuergerUpdateView.NAME);
         edit.addClickListener(clickEvent -> {
             if (grid.getSelectedRows().size() != 1)
                 return;
@@ -164,7 +167,7 @@ public class BuergerGrid extends CustomComponent {
     }
 
     private void createCreate() {
-        create = new ActionButton(controller, SimpleAction.create, BuergerCreateView.NAME);
+        create = new ActionButton(resolver, SimpleAction.create, BuergerCreateView.NAME);
         create.addClickListener(clickEvent -> {
             controller.getNavigator().navigateTo(BuergerCreateView.NAME);
         });
@@ -183,11 +186,11 @@ public class BuergerGrid extends CustomComponent {
                 reset.click();
             refresh();
         });
-        search.setId(String.format("%s_SEARCH_BUTTON", BuergerViewController.I18N_BASE_PATH));
+        search.setId(String.format("%s_SEARCH_BUTTON", BuergerI18nResolver.I18N_BASE_PATH));
     }
 
     private void createFilter() {
-        filter.setId(String.format("%s_QUERY_FIELD", BuergerViewController.I18N_BASE_PATH));
+        filter.setId(String.format("%s_QUERY_FIELD", BuergerI18nResolver.I18N_BASE_PATH));
         filter.focus();
         filter.setWidth("100%");
     }
@@ -200,7 +203,7 @@ public class BuergerGrid extends CustomComponent {
             controller.getEventbus().notify(controller.getRequestKey(RequestEvent.READ_LIST));
             filter.setValue("");
         });
-        reset.setId(String.format("%s_RESET_BUTTON", BuergerViewController.I18N_BASE_PATH));
+        reset.setId(String.format("%s_RESET_BUTTON", BuergerI18nResolver.I18N_BASE_PATH));
     }
 
     private void setButtonVisability() {

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerPartnerTab.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerPartnerTab.java
@@ -11,6 +11,7 @@ import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
 import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
 import de.muenchen.vaadin.guilib.components.GenericConfirmationWindow;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.views.TableSelectWindow;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
@@ -21,20 +22,22 @@ import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getEntityFieldPath;
  */
 public class BuergerPartnerTab extends CustomComponent {
 
-    private BuergerViewController controller;
+    private final BuergerViewController controller;
+    private final BuergerI18nResolver resolver;
     private GenericGrid grid;
     private ActionButton delete;
 
-    public BuergerPartnerTab(BuergerViewController controller, String navigateToForDetail, String navigateToForCreate, String navigateToForAdd, String from) {
+    public BuergerPartnerTab(BuergerViewController controller, BuergerI18nResolver resolver, String navigateToForDetail, String navigateToForCreate, String navigateToForAdd, String from) {
 
         this.controller = controller;
+        this.resolver = resolver;
 
-        ActionButton create = new ActionButton(controller, SimpleAction.create, navigateToForCreate);
+        ActionButton create = new ActionButton(resolver, SimpleAction.create, navigateToForCreate);
         create.addClickListener(clickEvent -> {
             if (grid.getContainerDataSource().size() == 0) {
                 controller.getNavigator().navigateTo(navigateToForCreate);
             } else {
-                GenericConfirmationWindow window = new GenericConfirmationWindow(controller, SimpleAction.override, e -> {
+                GenericConfirmationWindow window = new GenericConfirmationWindow(resolver, SimpleAction.override, e -> {
                     controller.getNavigator().navigateTo(navigateToForCreate);
                 });
                 getUI().addWindow(window);
@@ -42,14 +45,14 @@ public class BuergerPartnerTab extends CustomComponent {
                 window.focus();
             }
         });
-        ActionButton add = new ActionButton(controller, SimpleAction.add, navigateToForAdd);
+        ActionButton add = new ActionButton(resolver, SimpleAction.add, navigateToForAdd);
         add.addClickListener(clickEvent -> {
             if (grid.getContainerDataSource().size() == 0) {
-                getUI().addWindow(new TableSelectWindow(controller, controller.getViewFactory().generateBuergerPartnerSearchTable()));
+                getUI().addWindow(new TableSelectWindow(controller, resolver, controller.getViewFactory().generateBuergerPartnerSearchTable()));
                 //controller.postEvent(controller.buildAppEvent(EventType.ADD_PARTNER));
             } else {
                 GenericConfirmationWindow window =
-                        new GenericConfirmationWindow(controller, SimpleAction.override, e -> getUI().addWindow(new TableSelectWindow(controller, controller.getViewFactory().generateBuergerPartnerSearchTable())));
+                        new GenericConfirmationWindow(resolver, SimpleAction.override, e -> getUI().addWindow(new TableSelectWindow(controller, resolver, controller.getViewFactory().generateBuergerPartnerSearchTable())));
                 getUI().addWindow(window);
                 window.center();
                 window.focus();
@@ -57,7 +60,7 @@ public class BuergerPartnerTab extends CustomComponent {
         });
 
 
-        delete = new ActionButton(controller, SimpleAction.delete, null);
+        delete = new ActionButton(resolver, SimpleAction.delete, null);
         delete.addClickListener(clickEvent -> {
             if (grid.getSelectedRows() != null) {
                 for (Object next : grid.getSelectedRows()) {
@@ -75,10 +78,10 @@ public class BuergerPartnerTab extends CustomComponent {
         grid.addSelectionListener(selectionEvent -> setButtonVisability());
 
         // set headers
-        this.grid.getColumn(Buerger.Field.vorname.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.geburtsdatum.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.nachname.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), I18nPaths.Type.column_header)));
-        this.grid.getColumn(Buerger.Field.augenfarbe.name()).setHeaderCaption(controller.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.vorname.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.geburtsdatum.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.nachname.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), I18nPaths.Type.column_header)));
+        this.grid.getColumn(Buerger.Field.augenfarbe.name()).setHeaderCaption(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), I18nPaths.Type.column_header)));
 
         // Layout für die Schaltflächen über der Tabelle
         HorizontalLayout hlayout = new HorizontalLayout(create, add, delete);
@@ -88,7 +91,7 @@ public class BuergerPartnerTab extends CustomComponent {
         vlayout.setSpacing(true);
         vlayout.setMargin(true);
 
-        setId(String.format("%s_%s_%s_PARENT_TAB", navigateToForDetail, from, BuergerViewController.I18N_BASE_PATH));
+        setId(String.format("%s_%s_%s_PARENT_TAB", navigateToForDetail, from, BuergerI18nResolver.I18N_BASE_PATH));
         setCompositionRoot(vlayout);
     }
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerReadForm.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerReadForm.java
@@ -12,6 +12,7 @@ import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
 import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.services.model.BuergerDatastore;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class BuergerReadForm extends CustomComponent implements Consumer<Event<B
 
     final BeanFieldGroup<Buerger> binder = new BeanFieldGroup<Buerger>(Buerger.class);
     final BuergerViewController controller;
+    final BuergerI18nResolver resolver;
     
     private final String navigateToUpdate;
     private final String navigateBack;
@@ -48,9 +50,10 @@ public class BuergerReadForm extends CustomComponent implements Consumer<Event<B
      * @param navigateToUpdate
      * @param navigateBack
      */
-    public BuergerReadForm(BuergerViewController controller, final String navigateToUpdate, String navigateBack) {
+    public BuergerReadForm(BuergerViewController controller, BuergerI18nResolver resolver, final String navigateToUpdate, String navigateBack) {
         
         this.controller = controller;
+        this.resolver = resolver;
         this.navigateToUpdate = navigateToUpdate;
         this.navigateBack = navigateBack;
 
@@ -70,36 +73,36 @@ public class BuergerReadForm extends CustomComponent implements Consumer<Event<B
         layout.setMargin(true);
         
         // headline
-        Label headline = new Label(controller.resolveRelative(getFormPath(SimpleAction.read, I18nPaths.Component.headline, Type.label)));
+        Label headline = new Label(resolver.resolveRelative(getFormPath(SimpleAction.read, I18nPaths.Component.headline, Type.label)));
         headline.addStyleName(ValoTheme.LABEL_H3);
         layout.addComponent(headline);
 
         layout.addComponent(controller.getUtil().createFormTextField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.label)),
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.input_prompt)),
-                Buerger.Field.vorname.name(), BuergerViewController.I18N_BASE_PATH));
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.input_prompt)),
+                Buerger.Field.vorname.name(), BuergerI18nResolver.I18N_BASE_PATH));
         layout.addComponent(controller.getUtil().createFormTextField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.label)),
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.input_prompt)),
-                Buerger.Field.nachname.name(), BuergerViewController.I18N_BASE_PATH));
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.input_prompt)),
+                Buerger.Field.nachname.name(), BuergerI18nResolver.I18N_BASE_PATH));
         layout.addComponent(controller.getUtil().createFormComboBox(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), Type.label)),
                 Buerger.Field.augenfarbe.name(),
                 Augenfarbe.class));
         layout.addComponent(controller.getUtil().createFormDateField(
-                binder, controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.label)),
-                Buerger.Field.geburtsdatum.name(), BuergerViewController.I18N_BASE_PATH));
+                binder, resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.label)),
+                Buerger.Field.geburtsdatum.name(), BuergerI18nResolver.I18N_BASE_PATH));
         
         // auf 'read only setzen
         this.binder.setReadOnly(true);
         layout.addComponent(buttonLayout);
         // die Schaltfläche zum Aktualisieren
-        ActionButton backButton = new ActionButton(controller, SimpleAction.back, this.navigateBack);
+        ActionButton backButton = new ActionButton(resolver, SimpleAction.back, this.navigateBack);
         backButton.addClickListener(clickEvent -> controller.getNavigator().navigateTo(getNavigateBack()));
         buttonLayout.addComponent(backButton);
 
         // die Schaltfläche zum Bearbeiten
-        ActionButton updateButton = new ActionButton(controller, SimpleAction.update,this.navigateToUpdate);
+        ActionButton updateButton = new ActionButton(resolver, SimpleAction.update,this.navigateToUpdate);
         updateButton.addClickListener(clickEvent -> {
             controller.getEventbus().notify(controller.getRequestKey(RequestEvent.READ_SELECTED), reactor.bus.Event.wrap(binder.getItemDataSource().getBean()));
             controller.getNavigator().navigateTo(navigateToUpdate);

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerUpdateForm.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerUpdateForm.java
@@ -16,6 +16,7 @@ import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
 import de.muenchen.vaadin.guilib.components.GenericErrorNotification;
 import de.muenchen.vaadin.guilib.util.ValidatorFactory;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.services.model.BuergerDatastore;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
@@ -26,7 +27,6 @@ import reactor.fn.Consumer;
 import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.*;
 
 /**
- *
  * @author claus
  */
 public class BuergerUpdateForm extends CustomComponent implements Consumer<Event<BuergerDatastore>> {
@@ -38,6 +38,7 @@ public class BuergerUpdateForm extends CustomComponent implements Consumer<Event
 
     private final BeanFieldGroup<Buerger> binder = new BeanFieldGroup<Buerger>(Buerger.class);
     private final BuergerViewController controller;
+    private final BuergerI18nResolver resolver;
 
     private final String navigateTo;
     private final String navigateBack;
@@ -52,9 +53,10 @@ public class BuergerUpdateForm extends CustomComponent implements Consumer<Event
      * @param navigateTo
      * @param navigateBack
      */
-    public BuergerUpdateForm(BuergerViewController controller, final String navigateTo, String navigateBack) {
+    public BuergerUpdateForm(BuergerViewController controller, BuergerI18nResolver resolver, final String navigateTo, String navigateBack) {
 
         this.controller = controller;
+        this.resolver = resolver;
         this.navigateTo = navigateTo;
         this.navigateBack = navigateBack;
 
@@ -76,49 +78,49 @@ public class BuergerUpdateForm extends CustomComponent implements Consumer<Event
         layout.setMargin(true);
 
         // headline
-        Label headline = new Label(controller.resolveRelative(getFormPath(SimpleAction.create, I18nPaths.Component.headline, Type.label)));
+        Label headline = new Label(resolver.resolveRelative(getFormPath(SimpleAction.create, I18nPaths.Component.headline, Type.label)));
         headline.addStyleName(ValoTheme.LABEL_H3);
         layout.addComponent(headline);
 
-        Validator val0 = ValidatorFactory.getValidator(ValidatorFactory.Type.DIAKRITISCH, controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validationstring)), "true");
-        
+        Validator val0 = ValidatorFactory.getValidator(ValidatorFactory.Type.DIAKRITISCH, resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validationstring)), "true");
+
         TextField firstField = controller.getUtil().createFormTextField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.label)),
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.input_prompt)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.vorname.name(), Type.input_prompt)),
                 Buerger.Field.vorname.name(),
-                BuergerViewController.I18N_BASE_PATH);
+                BuergerI18nResolver.I18N_BASE_PATH);
         firstField.focus();
         firstField.addValidator(val0);
-        firstField.addValidator(new StringLengthValidator(controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), 1, Integer.MAX_VALUE, false));
+        firstField.addValidator(new StringLengthValidator(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), 1, Integer.MAX_VALUE, false));
         layout.addComponent(firstField);
-        
+
         // alle anderen Felder
         TextField secField = controller.getUtil().createFormTextField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.label)),
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.input_prompt)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.input_prompt)),
                 Buerger.Field.nachname.name(),
-                BuergerViewController.I18N_BASE_PATH);
+                BuergerI18nResolver.I18N_BASE_PATH);
         secField.addValidator(val0);
-        secField.addValidator(new StringLengthValidator(controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), 1, Integer.MAX_VALUE, false));
+        secField.addValidator(new StringLengthValidator(resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), 1, Integer.MAX_VALUE, false));
         layout.addComponent(secField);
         ComboBox cb = controller.getUtil().createFormComboBox(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), Type.label)),
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.augenfarbe.name(), Type.label)),
                 Buerger.Field.augenfarbe.name(),
                 Augenfarbe.class);
         layout.addComponent(cb);
         DateField birthdayfield = controller.getUtil().createFormDateField(binder,
-                controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.label)),
-                Buerger.Field.geburtsdatum.name(), BuergerViewController.I18N_BASE_PATH);
-        String errorMsg = controller.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.validation));
+                resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.label)),
+                Buerger.Field.geburtsdatum.name(), BuergerI18nResolver.I18N_BASE_PATH);
+        String errorMsg = resolver.resolveRelative(getEntityFieldPath(Buerger.Field.geburtsdatum.name(), Type.validation));
         birthdayfield.addValidator(ValidatorFactory.getValidator(ValidatorFactory.Type.DATE_RANGE, errorMsg, "start", null));
-        birthdayfield.addValidator(ValidatorFactory.getValidator(ValidatorFactory.Type.NULL, controller.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), "false"));
-        layout.addComponent(birthdayfield); 
-        
-        
+        birthdayfield.addValidator(ValidatorFactory.getValidator(ValidatorFactory.Type.NULL, resolver.resolveRelative(getEntityFieldPath(Buerger.Field.nachname.name(), Type.validation)), "false"));
+        layout.addComponent(birthdayfield);
+
+
         layout.addComponent(buttonLayout);
         // die Schaltfläche zum Aktualisieren
 
-        final ActionButton updateButton = new ActionButton(controller, SimpleAction.save, "lasdfölkjef");
+        final ActionButton updateButton = new ActionButton(resolver, SimpleAction.save, "lasdfölkjef");
         updateButton.addClickListener(clickEvent1 -> {
             try {
                 binder.commit();
@@ -126,15 +128,15 @@ public class BuergerUpdateForm extends CustomComponent implements Consumer<Event
                 controller.getEventbus().notify(controller.getRequestKey(RequestEvent.UPDATE), reactor.bus.Event.wrap(buerger));
                 getNavigator().navigateTo(getNavigateTo());
             } catch (FieldGroup.CommitException e) {
-                GenericErrorNotification error = new GenericErrorNotification(controller.resolveRelative(getNotificationPath(I18nPaths.NotificationType.failure, SimpleAction.save, Type.label)),
-                        controller.resolveRelative(getNotificationPath(I18nPaths.NotificationType.failure, SimpleAction.save, Type.text)));
+                GenericErrorNotification error = new GenericErrorNotification(resolver.resolveRelative(getNotificationPath(I18nPaths.NotificationType.failure, SimpleAction.save, Type.label)),
+                        resolver.resolveRelative(getNotificationPath(I18nPaths.NotificationType.failure, SimpleAction.save, Type.text)));
                 error.show(Page.getCurrent());
             }
         });
         buttonLayout.addComponent(updateButton);
 
         // die Schaltfläche zum Abbrechen
-        final ActionButton back = new ActionButton(controller, SimpleAction.back, "egal");
+        final ActionButton back = new ActionButton(resolver, SimpleAction.back, "egal");
         back.addClickListener(clickEvent -> getNavigator().navigateTo(getNavigateBack()));
         buttonLayout.addComponent(back);
 

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/KindGrid.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/KindGrid.java
@@ -6,6 +6,7 @@
 package de.muenchen.vaadin.ui.components;
 
 import de.muenchen.vaadin.demo.api.local.Buerger;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.services.model.BuergerDatastore;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
@@ -15,8 +16,8 @@ import de.muenchen.vaadin.ui.controller.BuergerViewController;
  */
 public class KindGrid extends GenericGrid {
 
-    public KindGrid(BuergerViewController controller) {
-        super(controller, Buerger.class);
+    public KindGrid(BuergerI18nResolver resolver) {
+        super(resolver, Buerger.class);
     }
 
     @Override

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/PartnerGrid.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/PartnerGrid.java
@@ -6,6 +6,7 @@
 package de.muenchen.vaadin.ui.components;
 
 import de.muenchen.vaadin.demo.api.local.Buerger;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.services.model.BuergerDatastore;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
@@ -15,8 +16,8 @@ import de.muenchen.vaadin.ui.controller.BuergerViewController;
  */
 public class PartnerGrid extends GenericGrid {
 
-    public PartnerGrid(BuergerViewController controller) {
-        super(controller, Buerger.class);
+    public PartnerGrid(BuergerI18nResolver resolver) {
+        super(resolver, Buerger.class);
     }
 
     @Override

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/BuergerViewController.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/BuergerViewController.java
@@ -16,6 +16,7 @@ import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
 import de.muenchen.vaadin.guilib.components.GenericSuccessNotification;
 import de.muenchen.vaadin.guilib.services.MessageService;
 import de.muenchen.vaadin.guilib.util.VaadinUtil;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.services.BuergerService;
 import de.muenchen.vaadin.services.model.BuergerDatastore;
 import de.muenchen.vaadin.ui.app.MainUI;
@@ -45,10 +46,8 @@ import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.*;
  */
 @SpringComponent
 @UIScope
-public class BuergerViewController implements Serializable, I18nResolver {
+public class BuergerViewController implements Serializable{
 
-    // TODO entweder hier oder im I18nServiceConfigImpl angeben
-    public static final String I18N_BASE_PATH = "buerger";
     private static final long serialVersionUID = 1L;
     /** Logger */
     private static final Logger LOG = LoggerFactory.getLogger(BuergerViewController.class);
@@ -61,9 +60,8 @@ public class BuergerViewController implements Serializable, I18nResolver {
     /** Event Bus zur Kommunikation */
     @Autowired
     private EventBus eventbus;
-    /** {@link MessageService} zur Auflösung der Platzhalter */
     @Autowired
-    private MessageService msg;
+    private BuergerI18nResolver resolver;
     /** {@link UI} {@link Navigator} */
     private Navigator navigator;
     /** BuergerViewFactory zum erstellen der Components */
@@ -451,61 +449,16 @@ public class BuergerViewController implements Serializable, I18nResolver {
 
     private void showNotification(NotificationType type, SimpleAction action, Buerger.Rel relation) {
         GenericSuccessNotification succes = new GenericSuccessNotification(
-                resolveRelative(getNotificationPath(type, action, Type.label, relation.name())),
-                resolveRelative(getNotificationPath(type, action, Type.text, relation.name())));
+                resolver.resolveRelative(getNotificationPath(type, action, Type.label, relation.name())),
+                resolver.resolveRelative(getNotificationPath(type, action, Type.text, relation.name())));
         succes.show(Page.getCurrent());
     }
 
     private void showNotification(NotificationType type, SimpleAction action) {
         GenericSuccessNotification succes = new GenericSuccessNotification(
-                resolveRelative(getNotificationPath(type, action, Type.label)),
-                resolveRelative(getNotificationPath(type, action, Type.text)));
+                resolver.resolveRelative(getNotificationPath(type, action, Type.label)),
+                resolver.resolveRelative(getNotificationPath(type, action, Type.text)));
         succes.show(Page.getCurrent());
     }
 
-    ////////////////////////
-    // I18n Operations //
-    ////////////////////////
-
-    /**
-     * Resolve the path (e.g. "asdf.label").
-     *
-     * @param path the path.
-     * @return the resolved String.
-     */
-    @Override
-    public String resolve(String path) {
-        return msg.get(path);
-    }
-
-    /**
-     * Resolve the relative path (e.g. "asdf.label").
-     * <p>
-     * The base path will be appended at start and then read from the properties.
-     *
-     * @param relativePath the path to add to the base path.
-     * @return the resolved String.
-     */
-    @Override
-    public String resolveRelative(String relativePath) {
-        return msg.get(I18N_BASE_PATH + "." + relativePath);
-    }
-
-    @Override
-    public String getBasePath() {
-        return I18N_BASE_PATH;
-    }
-
-    /**
-     * Resolve the relative path (e.g. ".asdf.label") to a icon.
-     * <p>
-     * The base path will be appended at start and then read from the properties.
-     *
-     * @param relativePath the path to add to the base path.
-     * @return the resolved String.
-     */
-    @Override
-    public FontAwesome resolveIcon(String relativePath) {
-        return msg.getFontAwesome(I18N_BASE_PATH + "." + relativePath + ".icon");
-    }
 }

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/factorys/BuergerViewFactory.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/controller/factorys/BuergerViewFactory.java
@@ -8,6 +8,7 @@ import de.muenchen.eventbus.events.Association;
 import de.muenchen.eventbus.selector.Key;
 import de.muenchen.eventbus.selector.entity.RequestEvent;
 import de.muenchen.vaadin.demo.api.local.Buerger;
+import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.components.*;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 import org.slf4j.Logger;
@@ -35,6 +36,8 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     private static final long serialVersionUID = 1L;
     @Autowired
     EventBus eventBus;
+    @Autowired
+    BuergerI18nResolver resolver;
     private BuergerViewController controller;
 
     /** Singeltons of Components. **/
@@ -61,7 +64,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     public BuergerCreateForm generateCreateForm(String navigateTo) {
         LOG.debug("creating 'create' buerger form");
         if (!createForm.isPresent()) {
-            BuergerCreateForm form = new BuergerCreateForm(controller, navigateTo, null);
+            BuergerCreateForm form = new BuergerCreateForm(controller, resolver, navigateTo, null);
             createForm = Optional.of(form);
         }
         return createForm.get();
@@ -70,7 +73,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     public BuergerCreateForm generateCreateChildForm(String navigateTo) {
         LOG.debug("creating 'create child' buerger form");
         if (!createChildForm.isPresent()) {
-            BuergerCreateForm form = new BuergerCreateForm(controller, navigateTo, Buerger.Rel.kinder.name());
+            BuergerCreateForm form = new BuergerCreateForm(controller, resolver, navigateTo, Buerger.Rel.kinder.name());
             createChildForm = Optional.of(form);
         }
         return createChildForm.get();
@@ -79,7 +82,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     public BuergerCreateForm generateCreatePartnerForm(String navigateTo) {
         LOG.debug("creating 'create partner' buerger form");
         if (!createPartnerForm.isPresent()) {
-            BuergerCreateForm form = new BuergerCreateForm(controller, navigateTo, Buerger.Rel.partner.name());
+            BuergerCreateForm form = new BuergerCreateForm(controller, resolver, navigateTo, Buerger.Rel.partner.name());
             createPartnerForm = Optional.of(form);
         }
         return createPartnerForm.get();
@@ -95,7 +98,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
      */
     public BuergerChildTab generateChildTab(String navigateToForDetail, String navigateForCreate, String navigateBack) {
         if (!childTab.isPresent()) {
-            BuergerChildTab tab = new BuergerChildTab(controller, navigateToForDetail, navigateForCreate, navigateBack);
+            BuergerChildTab tab = new BuergerChildTab(controller, resolver, navigateToForDetail, navigateForCreate, navigateBack);
             childTab = Optional.of(tab);
         }
         return childTab.get();
@@ -103,7 +106,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
 
     public BuergerPartnerTab generatePartnerTab(String navigateToForDetail, String navigateForCreate, String navigateForAdd, String navigateBack) {
         if (!partnerTab.isPresent()) {
-            BuergerPartnerTab tab = new BuergerPartnerTab(controller, navigateToForDetail, navigateForCreate, navigateForAdd, navigateBack);
+            BuergerPartnerTab tab = new BuergerPartnerTab(controller, resolver, navigateToForDetail, navigateForCreate, navigateForAdd, navigateBack);
             partnerTab = Optional.of(tab);
         }
         return partnerTab.get();
@@ -112,7 +115,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     public BuergerUpdateForm generateUpdateForm(String navigateTo, String navigateBack) {
         LOG.debug("creating 'update' buerger form");
         if (!updateForm.isPresent()) {
-            BuergerUpdateForm form = new BuergerUpdateForm(controller, navigateTo, navigateBack);
+            BuergerUpdateForm form = new BuergerUpdateForm(controller, resolver, navigateTo, navigateBack);
             controller.getEventbus().on(controller.getResponseKey().toSelector(), form);
             updateForm = Optional.of(form);
         }
@@ -123,7 +126,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     public BuergerReadForm generateReadForm(String navigateToUpdate, String navigateBack) {
         LOG.debug("creating 'read' buerger form");
         if (!readForm.isPresent()) {
-            BuergerReadForm form = new BuergerReadForm(controller, navigateToUpdate, navigateBack);
+            BuergerReadForm form = new BuergerReadForm(controller, resolver, navigateToUpdate, navigateBack);
             controller.getEventbus().on(controller.getResponseKey().toSelector(), form);
             readForm = Optional.of(form);
         }
@@ -163,7 +166,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
 
     public KindGrid generateChildTable(String navigateToForDetail) {
         LOG.debug("creating table for children");
-        KindGrid grid = new KindGrid(controller);
+        KindGrid grid = new KindGrid(resolver);
         grid.setSizeFull();
         grid.setSelectionMode(Grid.SelectionMode.MULTI);
         grid.addItemClickListener(itemClickEvent -> {
@@ -193,7 +196,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
     public PartnerGrid generatePartnerTable(String navigateToForDetail) {
 
         LOG.debug("creating table for partner");
-        PartnerGrid table = new PartnerGrid(controller);
+        PartnerGrid table = new PartnerGrid(resolver);
         table.setSizeFull();
         table.setSelectionMode(Grid.SelectionMode.MULTI);
         table.addItemClickListener(itemClickEvent -> {
@@ -226,7 +229,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
 
     private GenericGrid createGrid() {
         LOG.debug("creating table for buerger");
-        GenericGrid grid = new GenericGrid(controller, Buerger.class);
+        GenericGrid grid = new GenericGrid(resolver, Buerger.class);
         grid.setColumns(Buerger.Field.getProperties());
         controller.getEventbus().on(controller.getResponseKey().toSelector(), grid);
         return grid;
@@ -234,7 +237,7 @@ public class BuergerViewFactory implements Serializable, Consumer<Event<?>> {
 
     public BuergerGrid generateBuergerGrid() {
         LOG.debug("creating buergerGrid");
-        BuergerGrid buergerGrid = new BuergerGrid(controller);
+        BuergerGrid buergerGrid = new BuergerGrid(controller, resolver);
         return buergerGrid;
     }
 

--- a/vadin-demo-gui/src/main/resources/application.properties
+++ b/vadin-demo-gui/src/main/resources/application.properties
@@ -114,17 +114,37 @@ i18n.de-DE.buerger.notification.warning.save.text = Bitte füllen Sie alle Felde
 i18n.de-DE.buerger.notification.warning.save.label = Warnung
 
 ## Errors
-i18n.de-DE.buerger.notification.error.delete.label.409 = Fehler
+i18n.de-DE.buerger.notification.error.create.label.timeout = Zeitüberschreitung
+i18n.de-DE.buerger.notification.error.create.text.timeout = Beim Versuch die Daten zu speichern ist eine Zeitüberschreitung aufgetreten.
+i18n.de-DE.buerger.notification.error.create.label = Fehler
+i18n.de-DE.buerger.notification.error.create.text = Beim erstellen ist ein Fehler aufgetreten.
+
+i18n.de-DE.buerger.notification.error.update.label.timeout = Zeitüberschreitung
+i18n.de-DE.buerger.notification.error.update.text.timeout = Beim Versuch die Daten zu ändern ist eine Zeitüberschreitung aufgetreten.
+i18n.de-DE.buerger.notification.error.update.label = Fehler
+i18n.de-DE.buerger.notification.error.update.text = Beim ändern ist ein Fehler aufgetreten. Änderung wurde nicht gespeichert.
+
+i18n.de-DE.buerger.notification.error.read.label.timeout = Zeitüberschreitung
+i18n.de-DE.buerger.notification.error.read.text.timeout = Beim Versuch die Daten zu laden ist eine Zeitüberschreitung aufgetreten.
+i18n.de-DE.buerger.notification.error.read.label = Fehler
+i18n.de-DE.buerger.notification.error.read.text = Beim Lesen ist ein Fehler aufgetreten.
+
+i18n.de-DE.buerger.notification.error.association.label.timeout = Zeitüberschreitung
+i18n.de-DE.buerger.notification.error.association.text.timeout = Beim Versuch die Assoziation zu ändern ist eine Zeitüberschreitung aufgetreten.
+i18n.de-DE.buerger.notification.error.association.label = Fehler
+i18n.de-DE.buerger.notification.error.association.text = Beim ändern der Assoziation ist ein Fehler aufgetreten.
+
+i18n.de-DE.buerger.notification.error.delete.label.timeout = Zeitüberschreitung
+i18n.de-DE.buerger.notification.error.delete.text.timeout = Beim Versuch die Daten zu löschen ist eine Zeitüberschreitung aufgetreten.
+i18n.de-DE.buerger.notification.error.delete.label.409 = Konflikt
 i18n.de-DE.buerger.notification.error.delete.text.409 = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
-i18n.de-DE.buerger.notification.error.delete.label.400 = Fehler
-i18n.de-DE.buerger.notification.error.delete.text.400 = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
+i18n.de-DE.buerger.notification.error.delete.label.400 = Nicht gefunden
+i18n.de-DE.buerger.notification.error.delete.text.400 = Bürger existiert nicht.
 i18n.de-DE.buerger.notification.error.delete.label = Fehler
 i18n.de-DE.buerger.notification.error.delete.text = Ein Fehler ist aufgetreten. Löschen nicht möglich.
 
 
-
-
-
+# Anderes
 
 i18n.de-DE.buerger.nachname.validation = Dieses Feld darf nicht leer sein!
 i18n.de-DE.buerger.nachname.validationstring = Bitte verwenden Sie nur gültige Zeichen.

--- a/vadin-demo-gui/src/main/resources/application.properties
+++ b/vadin-demo-gui/src/main/resources/application.properties
@@ -97,8 +97,8 @@ i18n.de-DE.buerger.notification.success.copy.label = Bürger kopiert
 i18n.de-DE.buerger.notification.success.copy.text = Der Bürger wurde erfolgreich kopiert.
 i18n.de-DE.buerger.notification.warning.save.text = Bitte füllen Sie alle Felder mit gültigen Werten aus.
 i18n.de-DE.buerger.notification.warning.save.label = Warnung
-i18n.de-DE.buerger.notification.failure.delete.label = Fehler
-i18n.de-DE.buerger.notification.failure.delete.text = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
+i18n.de-DE.buerger.notification.error.delete.label = Fehler
+i18n.de-DE.buerger.notification.error.delete.text = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
 
 
 i18n.de-DE.buerger.notification.success.release.label = Bürger entfernt
@@ -111,10 +111,9 @@ i18n.de-DE.buerger.notification.success.release.text.partner = Partner wurde erf
 
 i18n.de-DE.buerger.notification.success.add.label = Bürger hinzugefügt
 i18n.de-DE.buerger.notification.success.add.text = Der Bürger wurde erfolgreich zum Bürger hinzugefügt.
-i18n.de-DE.buerger.notification.success.add.label.kinder = Kind hinzugefügt
-i18n.de-DE.buerger.notification.success.add.text.kinder = Das Kind wurde erfolgreich zum Bürger hinzugefügt.
-i18n.de-DE.buerger.notification.success.add.label.partner = Partner hinzugefügt
-i18n.de-DE.buerger.notification.success.add.text.partner = Der Partner wurde erfolgreich zum Bürger hinzugefügt.
+
+i18n.de-DE.buerger.notification.success.association.label = Änderung gespeichert
+i18n.de-DE.buerger.notification.success.association.text = Die Änderung wurde erfolgreich gespeichert.
 
 
 

--- a/vadin-demo-gui/src/main/resources/application.properties
+++ b/vadin-demo-gui/src/main/resources/application.properties
@@ -86,7 +86,10 @@ i18n.de-DE.buerger.partner.label = Partner
 i18n.de-DE.buerger.partner.column_header = Partner
 i18n.de-DE.buerger.partner.column_header.icon =
 i18n.de-DE.buerger.partner.input_prompt = Partner
+
 # Aktionsmeldungen
+
+## Success
 i18n.de-DE.buerger.notification.success.update.label = Bürger angepasst
 i18n.de-DE.buerger.notification.success.update.text = Der Bürger wurde erfolgreich angepasst und gespeichert.
 i18n.de-DE.buerger.notification.success.create.label = Bürger erstellt
@@ -95,25 +98,29 @@ i18n.de-DE.buerger.notification.success.delete.label = Bürger gelöscht
 i18n.de-DE.buerger.notification.success.delete.text = Der Bürger wurde erfolgreich gelöscht.
 i18n.de-DE.buerger.notification.success.copy.label = Bürger kopiert
 i18n.de-DE.buerger.notification.success.copy.text = Der Bürger wurde erfolgreich kopiert.
-i18n.de-DE.buerger.notification.warning.save.text = Bitte füllen Sie alle Felder mit gültigen Werten aus.
-i18n.de-DE.buerger.notification.warning.save.label = Warnung
-i18n.de-DE.buerger.notification.error.delete.label = Fehler
-i18n.de-DE.buerger.notification.error.delete.text = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
-
-
 i18n.de-DE.buerger.notification.success.release.label = Bürger entfernt
 i18n.de-DE.buerger.notification.success.release.text = Bürger wurde erfolgreich entfernt.
 i18n.de-DE.buerger.notification.success.release.label.kinder = Kind entfernt
 i18n.de-DE.buerger.notification.success.release.text.kinder = Kind wurde erfolgreich entfernt.
 i18n.de-DE.buerger.notification.success.release.label.partner = Partner entfernt
 i18n.de-DE.buerger.notification.success.release.text.partner = Partner wurde erfolgreich entfernt.
-
-
 i18n.de-DE.buerger.notification.success.add.label = Bürger hinzugefügt
 i18n.de-DE.buerger.notification.success.add.text = Der Bürger wurde erfolgreich zum Bürger hinzugefügt.
-
 i18n.de-DE.buerger.notification.success.association.label = Änderung gespeichert
 i18n.de-DE.buerger.notification.success.association.text = Die Änderung wurde erfolgreich gespeichert.
+
+## Warnings
+i18n.de-DE.buerger.notification.warning.save.text = Bitte füllen Sie alle Felder mit gültigen Werten aus.
+i18n.de-DE.buerger.notification.warning.save.label = Warnung
+
+## Errors
+i18n.de-DE.buerger.notification.error.delete.label.409 = Fehler
+i18n.de-DE.buerger.notification.error.delete.text.409 = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
+i18n.de-DE.buerger.notification.error.delete.label = Fehler
+i18n.de-DE.buerger.notification.error.delete.text = Ein Fehler ist aufgetreten. Löschen nicht möglich.
+
+
+
 
 
 

--- a/vadin-demo-gui/src/main/resources/application.properties
+++ b/vadin-demo-gui/src/main/resources/application.properties
@@ -116,6 +116,8 @@ i18n.de-DE.buerger.notification.warning.save.label = Warnung
 ## Errors
 i18n.de-DE.buerger.notification.error.delete.label.409 = Fehler
 i18n.de-DE.buerger.notification.error.delete.text.409 = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
+i18n.de-DE.buerger.notification.error.delete.label.400 = Fehler
+i18n.de-DE.buerger.notification.error.delete.text.400 = Bürger wird in anderer Entität referenziert. Löschen nicht möglich.
 i18n.de-DE.buerger.notification.error.delete.label = Fehler
 i18n.de-DE.buerger.notification.error.delete.text = Ein Fehler ist aufgetreten. Löschen nicht möglich.
 


### PR DESCRIPTION
## Beschreibung:

Hystrix wurde nun doch nicht verwendet. Es bietet auf GUI-Seite nicht den nötigen Mehrwert. Stattdessen wurden nun try-catch-Blöcke zum abfangen und ordentlichen weiterleiten von Fehlermeldungen zum User verwendet. In diesem Zusammenhang wurden die Error und FailureNotifications überarbeitet. Der Nutzer muss diese nun aktiv schließen, um zu verhindern, dass diese übersehen werden. https://github.com/xdoo/vaadin-demo/pull/151
## Branch-Checklist:
- [x] GUI getestet
- [x] Fehlverhalten provoziert und getestet
## Bestätigungen:
- [x] @darenegade 
- [x] @peter-mueller 
## Referenz:

closes #95 
