### PR TITLE
GenericGrid an Actions angepasst

### DIFF
--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
@@ -496,6 +496,10 @@ public class GenericGrid<T> extends CustomComponent {
     // Getter / Setter
     //--------------
 
+    /**
+     * Get all selected Entities of this grid.
+     * @return selected Entities.
+     */
     public List<T> getSelectedEntities(){
         return grid.getSelectedRows().stream()
                 .map(item -> (BeanItem<T>) grid.getContainerDataSource().getItem(item))
@@ -503,6 +507,12 @@ public class GenericGrid<T> extends CustomComponent {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Get a single selected Entitiy.
+     * If more than one Entities are selected, this method will return the first one.
+     *
+     * @return single selected entitiy
+     */
     public T getSelectedEntity(){
         return grid.getSelectedRows().stream()
                 .map(item -> (BeanItem<T>) grid.getContainerDataSource().getItem(item))

--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
@@ -509,7 +509,7 @@ public class GenericGrid<T> extends CustomComponent {
 
     /**
      * Get a single selected Entitiy.
-     * If more than one Entities are selected, this method will return the first one.
+     * If more than one Entity is selected, this method will return the first one.
      *
      * @return single selected entitiy
      */

--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
@@ -166,7 +166,7 @@ public class GenericGrid<T> extends CustomComponent {
     }
 
     private void createDelete() {
-        ActionButton deleteButton = new ActionButton(controller.getResolver(), SimpleAction.delete);;
+        ActionButton deleteButton = new ActionButton(controller.getResolver(), SimpleAction.delete);
 
         deleteButton.addActionPerformer(getListActionOnSelected()::delete);
         delete = Optional.of(deleteButton);

--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
@@ -1,15 +1,29 @@
 package de.muenchen.vaadin.guilib.components;
 
+import com.vaadin.data.util.AbstractBeanContainer;
 import com.vaadin.data.util.BeanItem;
 import com.vaadin.data.util.BeanItemContainer;
 import com.vaadin.event.ShortcutAction;
+import com.vaadin.navigator.Navigator;
 import com.vaadin.server.FontAwesome;
-import com.vaadin.ui.*;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.CssLayout;
+import com.vaadin.ui.CustomComponent;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
+import de.muenchen.eventbus.EventBus;
 import de.muenchen.eventbus.selector.entity.RequestEvent;
 import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
+import de.muenchen.vaadin.demo.i18nservice.I18nResolver;
 import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
+import de.muenchen.vaadin.guilib.components.actions.EntityActions;
+import de.muenchen.vaadin.guilib.components.actions.EntityListActions;
+import de.muenchen.vaadin.guilib.components.actions.EntitySingleActions;
+import de.muenchen.vaadin.guilib.components.actions.NavigateActions;
 import de.muenchen.vaadin.guilib.controller.EntityController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,69 +150,43 @@ public class GenericGrid<T> extends CustomComponent {
 
     private void createRead(String navigateToRead) {
         ActionButton readButton = new ActionButton(controller.getResolver(), SimpleAction.read);
-        readButton.addClickListener(clickEvent -> {
-            controller.getEventbus().notify(controller.getRequestKey(RequestEvent.READ_SELECTED), reactor.bus.Event.wrap(grid.getSelectedRows().toArray()[0]));
-            controller.getNavigator().navigateTo(navigateToRead);
-        });
+
+        readButton.addActionPerformer(getSingleActionOnSelected()::read);
+        readButton.addActionPerformer(getNavigateAction(navigateToRead)::navigate);
+
         readButton.setVisible(false);
         read = Optional.of(readButton);
     }
 
     private void createCopy() {
         ActionButton copyButton = new ActionButton(controller.getResolver(), SimpleAction.copy);
-        copyButton.addClickListener(clickEvent -> {
-            LOG.debug("copying selected items");
-            if (grid.getSelectedRows() != null) {
-                grid.getSelectedRows().stream()
-                        .peek(grid::deselect)
-                        .map(itemID -> (BeanItem<T>) grid.getContainerDataSource().getItem(itemID))
-                        .forEach(beanItem ->
-                                        controller.getEventbus().notify(controller.getRequestKey(RequestEvent.CREATE), reactor.bus.Event.wrap(beanItem.getBean()))
-                        );
 
-
-            }
-        });
+        copyButton.addActionPerformer(getListActionOnSelected()::create);
         copy = Optional.of(copyButton);
     }
 
     private void createDelete() {
-        ActionButton deleteButton = new ActionButton(controller.getResolver(), SimpleAction.delete);
-        deleteButton.addClickListener(clickEvent -> {
-            LOG.debug("deleting selected items");
-            if (grid.getSelectedRows() != null) {
-                grid.getSelectedRows().stream()
-                        .peek(grid::deselect)
-                        .map(itemID -> (BeanItem<T>) grid.getContainerDataSource().getItem(itemID))
-                        .forEach(beanItem ->
-                                        controller.getEventbus().notify(controller.getRequestKey(RequestEvent.DELETE), reactor.bus.Event.wrap(beanItem.getBean()))
-                        );
+        ActionButton deleteButton = new ActionButton(controller.getResolver(), SimpleAction.delete);;
 
-
-            }
-        });
+        deleteButton.addActionPerformer(getListActionOnSelected()::delete);
         delete = Optional.of(deleteButton);
     }
 
     private void createEdit(String navigateToEdit) {
         ActionButton editButton = new ActionButton(controller.getResolver(), SimpleAction.update);
-        editButton.addClickListener(clickEvent -> {
-            if (grid.getSelectedRows().size() == 1) {
-                LOG.debug("update selected");
-                T buerger = ((BeanItem<T>) grid.getContainerDataSource().getItem(grid.getSelectedRows().toArray()[0])).getBean();
-                controller.getEventbus().notify(controller.getRequestKey(RequestEvent.READ_SELECTED), reactor.bus.Event.wrap(buerger));
-                controller.getNavigator().navigateTo(navigateToEdit);
-            }
-        });
+
+        editButton.addActionPerformer(getSingleActionOnSelected()::read);
+        editButton.addActionPerformer(getNavigateAction(navigateToEdit)::navigate);
+
         edit = Optional.of(editButton);
     }
 
     private void createCreate(String navigateToCreate) {
         ActionButton createButton = new ActionButton(controller.getResolver(), SimpleAction.create);
-        createButton.addClickListener(clickEvent -> {
-            controller.getNavigator().navigateTo(navigateToCreate);
-        });
+
+        createButton.addActionPerformer(getNavigateAction(navigateToCreate)::navigate);
         createButton.setVisible(Boolean.TRUE);
+
         create = Optional.of(createButton);
     }
 
@@ -206,13 +194,9 @@ public class GenericGrid<T> extends CustomComponent {
         search = new Button(FontAwesome.SEARCH);
         search.setStyleName(ValoTheme.BUTTON_ICON_ONLY);
         search.setClickShortcut(ShortcutAction.KeyCode.ENTER);
-        search.addClickListener(e -> {
-            LOG.debug("search clicked: " + filter.getValue());
-            if (filter.getValue() != null && filter.getValue().length() > 0)
-                controller.getEventbus().notify(controller.getRequestKey(RequestEvent.READ_LIST), reactor.bus.Event.wrap(filter.getValue()));
-            else
-                reset.click();
-        });
+
+        search.addClickListener(getEntityAction()::readList);
+
         search.setId(String.format("%s_SEARCH_BUTTON", controller.getResolver().getBasePath()));
     }
 
@@ -227,8 +211,8 @@ public class GenericGrid<T> extends CustomComponent {
         reset.setStyleName(ValoTheme.BUTTON_ICON_ONLY);
         reset.setClickShortcut(ShortcutAction.KeyCode.ESCAPE);
         reset.addClickListener(e -> {
-            controller.getEventbus().notify(controller.getRequestKey(RequestEvent.READ_LIST));
             filter.setValue("");
+            getEntityAction().readList(e);
         });
         reset.setId(String.format("%s_RESET_BUTTON", controller.getResolver().getBasePath()));
     }
@@ -414,9 +398,9 @@ public class GenericGrid<T> extends CustomComponent {
      * @param consumer   the consumer
      * @return the generic grid
      */
-    public GenericGrid<T> addMultiSelectButton(String buttonName, Consumer<List<T>> consumer) {
+    public GenericGrid<T> addMultiSelectButton(String buttonName, Consumer consumer) {
         Button button = new Button(buttonName);
-        customMultiSelectButtons.add(button);
+
         button.addClickListener(event -> {
             if (grid.getSelectedRows() != null) {
                 consumer.accept(grid.getSelectedRows().stream()
@@ -424,8 +408,8 @@ public class GenericGrid<T> extends CustomComponent {
                         .collect(Collectors.toList()));
             }
         });
-        topComponentsLayout.addComponent(button);
-        setButtonVisability();
+
+        addMultiSelectButton(button);
         return this;
     }
 
@@ -437,7 +421,8 @@ public class GenericGrid<T> extends CustomComponent {
      */
     public GenericGrid<T> addMultiSelectButton(Button button) {
 
-        //TODO after #147
+        customMultiSelectButtons.add(button);
+        topComponentsLayout.addComponent(button);
 
         setButtonVisability();
         return this;
@@ -452,14 +437,14 @@ public class GenericGrid<T> extends CustomComponent {
      */
     public GenericGrid<T> addSingleSelectButton(String buttonName, Consumer<T> consumer) {
         Button button = new Button(buttonName);
-        customSingleSelectButtons.add(button);
+
         button.addClickListener(event -> {
             if (grid.getSelectedRows().size() == 1) {
                 consumer.accept(((BeanItem<T>) grid.getContainerDataSource().getItem(grid.getSelectedRows().toArray()[0])).getBean());
             }
         });
-        topComponentsLayout.addComponent(button);
-        setButtonVisability();
+
+        addSingleSelectButton(button);
         return this;
     }
 
@@ -471,7 +456,8 @@ public class GenericGrid<T> extends CustomComponent {
      */
     public GenericGrid<T> addSingleSelectButton(Button button) {
 
-        //TODO after #147
+        customSingleSelectButtons.add(button);
+        topComponentsLayout.addComponent(button);
 
         setButtonVisability();
         return this;
@@ -486,10 +472,9 @@ public class GenericGrid<T> extends CustomComponent {
      */
     public GenericGrid<T> addButton(String buttonName, Runnable runnable) {
         Button button = new Button(buttonName);
-        customButtons.add(button);
+
         button.addClickListener(event -> runnable.run());
-        topComponentsLayout.addComponent(button);
-        button.setVisible(Boolean.TRUE);
+        addButton(button);
         return this;
     }
 
@@ -501,10 +486,82 @@ public class GenericGrid<T> extends CustomComponent {
      */
     public GenericGrid<T> addButton(Button button) {
 
-        //TODO after #147
+        customButtons.add(button);
+        topComponentsLayout.addComponent(button);
 
         button.setVisible(Boolean.TRUE);
         return this;
+    }
+    //--------------
+    // Getter / Setter
+    //--------------
+
+    public List<T> getSelectedEntities(){
+        return grid.getSelectedRows().stream()
+                .map(item -> (BeanItem<T>) grid.getContainerDataSource().getItem(item))
+                .map(BeanItem::getBean)
+                .collect(Collectors.toList());
+    }
+
+    public T getSelectedEntity(){
+        return grid.getSelectedRows().stream()
+                .map(item -> (BeanItem<T>) grid.getContainerDataSource().getItem(item))
+                .map(BeanItem::getBean)
+                .findFirst().get();
+    }
+
+
+    //--------------
+    //intern Helper-Methods
+    //--------------
+
+    private EntitySingleActions getSingleActionOnSelected(){
+        return new EntitySingleActions(
+                getResolver(),
+                this::getSelectedEntity,
+                getEventbus(),
+                getType()
+        );
+    }
+
+    private EntityListActions getListActionOnSelected(){
+        return new EntityListActions(
+                () -> grid.getSelectedRows().stream()
+                        .peek(grid::deselect)
+                        .map(itemID -> (BeanItem<T>) grid.getContainerDataSource().getItem(itemID))
+                        .map(BeanItem::getBean)
+                        .collect(Collectors.toList()),
+                getType(),
+                getEventbus()
+        );
+    }
+
+    private EntityActions getEntityAction(){
+        return new EntityActions(
+                filter::getValue,
+                getEventbus(),
+                getType()
+        );
+    }
+
+    private NavigateActions getNavigateAction(String navigateTo){
+        return new NavigateActions(getNavigator(), getEventbus(), navigateTo);
+    }
+
+    private Class<?> getType(){
+        return ((AbstractBeanContainer)grid.getContainerDataSource()).getBeanType();
+    }
+
+    private I18nResolver getResolver(){
+        return controller.getResolver();
+    }
+
+    private EventBus getEventbus(){
+        return controller.getEventbus();
+    }
+
+    private Navigator getNavigator(){
+        return controller.getNavigator();
     }
 
 }

--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/actions/EntityActions.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/actions/EntityActions.java
@@ -6,6 +6,8 @@ import de.muenchen.eventbus.selector.entity.RequestEvent;
 import reactor.bus.Event;
 import reactor.bus.EventBus;
 
+import java.util.function.Supplier;
+
 /**
  * Provides simple general Actions for an Entity.
  * They are designed to be used as ClickListeners with java8 method reference.
@@ -14,13 +16,12 @@ import reactor.bus.EventBus;
  * @version 1.0
  */
 public class EntityActions {
+    /** The supplier for the query. */
+    private final Supplier<String> filterSupplier;
     /** The EventBus for notifying the Action. */
     private final EventBus eventBus;
     /** The class of the Entity */
     private final Class entityClass;
-
-    /** The filter for the list of buergers */
-    private String q = null;
 
     /**
      * Creates new EntityActions defined by Class.
@@ -28,31 +29,15 @@ public class EntityActions {
      * @param eventBus    The eventBus notify on.
      * @param entityClass The class of the Entity.
      */
-    public EntityActions(EventBus eventBus, Class entityClass) {
+    public EntityActions(Supplier<String> filterSupplier, EventBus eventBus, Class entityClass) {
         if (entityClass == null)
             throw new NullPointerException();
         this.entityClass = entityClass;
         if (eventBus == null)
             throw new NullPointerException();
+
+        this.filterSupplier = filterSupplier;
         this.eventBus = eventBus;
-    }
-
-    /**
-     * Get the filter query for the actions.
-     *
-     * @return The query as String.
-     */
-    public String getQ() {
-        return q;
-    }
-
-    /**
-     * Set the filter query for the actions.
-     *
-     * @param q The desired query.
-     */
-    public void setQ(String q) {
-        this.q = q;
     }
 
     /**
@@ -60,11 +45,21 @@ public class EntityActions {
      * @param clickEvent can be null
      */
     public void readList(Button.ClickEvent clickEvent) {
-        if (q == null) {
+        String query = getQuery();
+
+        if (query == null) {
             getEventBus().notify(new RequestEntityKey(RequestEvent.READ_LIST, getEntityClass()));
         } else {
-            getEventBus().notify(new RequestEntityKey(RequestEvent.READ_LIST, getEntityClass()), Event.wrap(q));
+            getEventBus().notify(new RequestEntityKey(RequestEvent.READ_LIST, getEntityClass()), Event.wrap(query));
         }
+    }
+
+    /**
+     * Get the Query
+     * @return The query.
+     */
+    public String getQuery() {
+        return filterSupplier.get();
     }
 
     /**

--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/actions/EntityListActions.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/actions/EntityListActions.java
@@ -50,24 +50,27 @@ public class EntityListActions<T> {
      * Delete all the Entities from the Supplier.
      * @param clickEvent can be null
      */
-    public void delete(Button.ClickEvent clickEvent) {
+    public boolean delete(Button.ClickEvent clickEvent) {
         notifyRequest(RequestEvent.DELETE);
+        return true;
     }
 
     /**
      * Create all the Entities from the Supplier.
      * @param clickEvent can be null
      */
-    public void create(Button.ClickEvent clickEvent) {
+    public boolean create(Button.ClickEvent clickEvent) {
         notifyRequest(RequestEvent.CREATE);
+        return true;
     }
 
     /**
      * Update all the Entities from the Supplier.
      * @param clickEvent can be null
      */
-    public void update(Button.ClickEvent clickEvent) {
+    public boolean update(Button.ClickEvent clickEvent) {
         notifyRequest(RequestEvent.UPDATE);
+        return true;
     }
 
     /**
@@ -77,9 +80,11 @@ public class EntityListActions<T> {
      */
     private void notifyRequest(RequestEvent event) {
 
-        if (getEntityList() == null)
+        List<T> entityList = getEntityList();
+
+        if (entityList == null)
             throw new NullPointerException();
-        getEntityList().stream().forEach(buerger -> {
+        entityList.stream().forEach(buerger -> {
             final RequestEntityKey key = new RequestEntityKey(event, getEntityClass());
             getEventBus().notify(key, Event.wrap(buerger));
         });

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/buttons/node/listener/BuergerActions.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/buttons/node/listener/BuergerActions.java
@@ -4,12 +4,14 @@ import de.muenchen.eventbus.EventBus;
 import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.guilib.components.actions.EntityActions;
 
+import java.util.function.Supplier;
+
 /**
  * Created by p.mueller on 09.10.15.
  */
 public class BuergerActions extends EntityActions {
 
-    public BuergerActions(EventBus eventBus) {
-        super(eventBus, Buerger.class);
+    public BuergerActions(Supplier<String> filterSupplier, EventBus eventBus) {
+        super(filterSupplier, eventBus, Buerger.class);
     }
 }


### PR DESCRIPTION
## Beschreibung:

Die G-Grid benutzt nun die Actions vom Peter. 

Das BuergerChild Tab muss noch für das delete der Assoziationen angepasst werden. Hierzu brauch man aber eine "EntityAssociationListActions", was nicht Teil dieses Tickets ist.
## Branch-Checklist:
- [x] Doku im Code vollständig
- [ ] Im Wiki dokumentiert
- [x] MicroService getestet
- [x] GUI getestet
- [x] Barakuda Issue erstellt
## Bestätigungen:
- [x] @peter-mueller 
## Referenz:

closes #158
