### PR TITLE
EntityAssociationListAction erstellt und ChildTab nutzt die jetzt

### DIFF
--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/actions/EntityAssociationListAction.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/actions/EntityAssociationListAction.java
@@ -1,0 +1,118 @@
+package de.muenchen.vaadin.guilib.components.actions;
+
+import com.vaadin.server.Page;
+import com.vaadin.ui.Button;
+import de.muenchen.eventbus.events.Association;
+import de.muenchen.eventbus.selector.entity.RequestEntityKey;
+import de.muenchen.eventbus.selector.entity.RequestEvent;
+import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
+import de.muenchen.vaadin.demo.i18nservice.I18nResolver;
+import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
+import de.muenchen.vaadin.guilib.components.GenericWarningNotification;
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getNotificationPath;
+
+/**
+ * Provides simple Actions for changing an Association on a List of Associations.
+ * They are designed to be used as ClickListeners with java8 method reference.
+ *
+ * @author rene.zarwel
+ * @version 1.0
+ */
+public class EntityAssociationListAction<T> {
+
+    /** The EventBus for notifying the Action. */
+    private final EventBus eventBus;
+    /** The class of the Entity */
+    private final Class<T> entityClass;
+    /** The supplier for the Association. */
+    private final Supplier<List<Association<T>>> association;
+    /** The I18NResolver of this context **/
+    private final I18nResolver resolver;
+
+    /**
+     * Create new AssociationActions for the Entity with the single association.
+     *
+     * @param association The association.
+     * @param eventBus    The EventBus.
+     * @param entityClass The class of the Entity.
+     */
+    public EntityAssociationListAction(I18nResolver resolver, Supplier<List<Association<T>>> association, EventBus eventBus, Class<T> entityClass) {
+        if (eventBus == null) {
+            throw new NullPointerException();
+        }
+        if (entityClass == null) {
+            throw new NullPointerException();
+        }
+        if (association == null) {
+            throw new NullPointerException();
+        }
+
+        this.resolver = resolver;
+        this.eventBus = eventBus;
+        this.entityClass = entityClass;
+        this.association = association;
+    }
+
+    /**
+     * Add the associations to the selected Buerger.
+     * @param clickEvent can be null
+     */
+    public boolean addAssociations(Button.ClickEvent clickEvent) {
+        return getAssociations().stream()
+                .allMatch(association -> {
+            try {
+                getEventBus().notify(new RequestEntityKey(RequestEvent.ADD_ASSOCIATION, getEntityClass()), Event.wrap(association));
+                return true;
+            } catch (Exception e) { //TODO Find a good Exception Type
+                GenericWarningNotification warn = new GenericWarningNotification(
+                        resolver.resolveRelative(getNotificationPath(I18nPaths.NotificationType.warning, SimpleAction.save, I18nPaths.Type.label)),
+                        resolver.resolveRelative(getNotificationPath(I18nPaths.NotificationType.warning, SimpleAction.save, I18nPaths.Type.text)));
+                warn.show(Page.getCurrent());
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Remove the association from the selected Buerger.
+     * @param clickEvent can be null
+     */
+    public boolean removeAssociations(Button.ClickEvent clickEvent) {
+        return getAssociations().stream()
+                .allMatch(association -> {
+                    getEventBus().notify(new RequestEntityKey(RequestEvent.REMOVE_ASSOCIATION, getEntityClass()), Event.wrap(association));
+                    return true;
+                });
+
+    }
+
+    /**
+     * Get the EventBus.
+     * @return The EventBus.
+     */
+    public EventBus getEventBus() {
+        return eventBus;
+    }
+
+    /**
+     * Get the Association.
+     * @return The Association.
+     */
+    public List<Association<T>> getAssociations() {
+        return association.get();
+    }
+
+    /**
+     * Get the entity class.
+     * @return The class of the entity.
+     */
+    public Class<T> getEntityClass() {
+        return entityClass;
+    }
+}

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerChildTab.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/BuergerChildTab.java
@@ -3,17 +3,18 @@ package de.muenchen.vaadin.ui.components;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.HorizontalLayout;
 import de.muenchen.eventbus.events.Association;
-import de.muenchen.eventbus.selector.entity.RequestEvent;
 import de.muenchen.vaadin.demo.api.local.Buerger;
 import de.muenchen.vaadin.demo.i18nservice.I18nPaths;
+import de.muenchen.vaadin.demo.i18nservice.buttons.ActionButton;
 import de.muenchen.vaadin.demo.i18nservice.buttons.SimpleAction;
 import de.muenchen.vaadin.guilib.components.GenericGrid;
 import de.muenchen.vaadin.services.BuergerI18nResolver;
 import de.muenchen.vaadin.ui.app.views.BuergerDetailView;
 import de.muenchen.vaadin.ui.app.views.TableSelectWindow;
+import de.muenchen.vaadin.ui.components.buttons.node.listener.BuergerAssociationListActions;
 import de.muenchen.vaadin.ui.controller.BuergerViewController;
 
-import java.util.List;
+import java.util.stream.Collectors;
 
 import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getFormPath;
 
@@ -24,7 +25,7 @@ import static de.muenchen.vaadin.demo.i18nservice.I18nPaths.getFormPath;
 public class BuergerChildTab extends CustomComponent {
 
     private BuergerViewController controller;
-    private GenericGrid grid;
+    private GenericGrid<Buerger> grid;
 
     public BuergerChildTab(BuergerViewController controller, BuergerI18nResolver resolver, String navigateToForDetail, String navigateToForCreate, String navigateBack) {
 
@@ -42,18 +43,20 @@ public class BuergerChildTab extends CustomComponent {
                             HorizontalLayout layout = new HorizontalLayout(controller.getViewFactory().generateChildSearchTable());
                             layout.setMargin(true);
                             getUI().addWindow(new TableSelectWindow(controller, controller.getResolver(), layout));
-                        })
-                .addMultiSelectButton(
-                        controller.getResolver().resolveRelative(
-                                getFormPath(SimpleAction.delete,
-                                        I18nPaths.Component.button,
-                                        I18nPaths.Type.label)),
-                        buergers -> {
-                            ((List) buergers).stream().forEach(buerger -> {
-                                final Association<Buerger> association = new Association<>((Buerger) buerger, Buerger.Rel.kinder.name());
-                                controller.getEventbus().notify(controller.getRequestKey(RequestEvent.REMOVE_ASSOCIATION), association.asEvent());
-                            });
                         });
+
+
+        //Create Button to delete one or more associations
+        ActionButton deleteButton = new ActionButton(resolver, SimpleAction.delete);
+        BuergerAssociationListActions listAction = new BuergerAssociationListActions(resolver,
+                () -> grid.getSelectedEntities().stream()
+                        .map(buerger -> new Association<>( buerger, Buerger.Rel.kinder.name()))
+                        .collect(Collectors.toList()),
+                controller.getEventbus()
+        );
+        deleteButton.addActionPerformer(listAction::removeAssociations);
+        grid.addMultiSelectButton(deleteButton);
+
 
         HorizontalLayout layout = new HorizontalLayout(grid);
         layout.setSizeFull();

--- a/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/buttons/node/listener/BuergerAssociationListActions.java
+++ b/vadin-demo-gui/src/main/java/de/muenchen/vaadin/ui/components/buttons/node/listener/BuergerAssociationListActions.java
@@ -1,0 +1,27 @@
+package de.muenchen.vaadin.ui.components.buttons.node.listener;
+
+import de.muenchen.eventbus.events.Association;
+import de.muenchen.vaadin.demo.api.local.Buerger;
+import de.muenchen.vaadin.demo.i18nservice.I18nResolver;
+import de.muenchen.vaadin.guilib.components.actions.EntityAssociationListAction;
+import reactor.bus.EventBus;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Created by rene.zarwel on 15.10.15.
+ */
+public class BuergerAssociationListActions extends EntityAssociationListAction<Buerger> {
+
+    /**
+     * Create new AssociationActions for the Entity with the single association.
+     *
+     * @param resolver
+     * @param association The association.
+     * @param eventBus    The EventBus.
+     */
+    public BuergerAssociationListActions(I18nResolver resolver, Supplier<List<Association<Buerger>>> association, EventBus eventBus) {
+        super(resolver, association, eventBus, Buerger.class);
+    }
+}


### PR DESCRIPTION
## Beschreibung:

Nun können auch Listen von Associationen gelöscht werden.
## Branch-Checklist:
- [x] Doku im Code vollständig
- [ ] Im Wiki dokumentiert
- [x] MicroService getestet
- [x] GUI getestet
- [x] Barakuda Issue erstellt
## Bestätigungen:
- [x] @peter-mueller 
- [x] @FabianHoltkoetter 
## Referenz:

closes #177 
