### PR TITLE
#189 OID über db

### DIFF
--- a/Auditing/src/main/java/de/muenchen/auditing/AuditingServiceProducer.java
+++ b/Auditing/src/main/java/de/muenchen/auditing/AuditingServiceProducer.java
@@ -86,11 +86,6 @@ public class AuditingServiceProducer {
         SessionFactoryImpl sessionFactoryImpl = (SessionFactoryImpl) hibernateEntityManagerFactory.getSessionFactory();
         EventListenerRegistry registry = sessionFactoryImpl.getServiceRegistry().getService(EventListenerRegistry.class);
 
-        registry.getEventListenerGroup(EventType.POST_LOAD).clear();
-        registry.getEventListenerGroup(EventType.POST_DELETE).clear();
-        registry.getEventListenerGroup(EventType.POST_INSERT).clear();
-        registry.getEventListenerGroup(EventType.POST_UPDATE).clear();
-
         registry.getEventListenerGroup(EventType.POST_LOAD)
                 .appendListener(postLoadEvent -> {
                     Object eventEntity = postLoadEvent.getEntity();

--- a/Auditing/src/main/java/de/muenchen/auditing/AuditingServiceProducer.java
+++ b/Auditing/src/main/java/de/muenchen/auditing/AuditingServiceProducer.java
@@ -57,11 +57,13 @@ public class AuditingServiceProducer {
         try {
             json = mapper.writeValueAsString(entity);
         } catch (StackOverflowError err) {
-            LOG.error("StackOverFlow occurred while Marshalling Entity. Make sure to use @JsonManagedReference and @JsonBackReference on circular dependencies.");
-            json = entity.toString();
+            String message = "StackOverFlow occurred while Marshalling Entity. Make sure to use @JsonManagedReference and @JsonBackReference on circular dependencies.";
+            LOG.error(message);
+            json = message + "Class was: " + entity.getClass();
         } catch (JsonProcessingException e) {
-            LOG.error("Fehler beim JSON erstellen. Fehlermeldung: " + e.getMessage());
-            json = entity.toString();
+            String message = "Fehler beim JSON erstellen. Fehlermeldung: " + e.getMessage();
+            LOG.error(message);
+            json = message;
         }
 
         return json;

--- a/Service-Lib/src/main/java/de/muenchen/service/BaseEntity.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/BaseEntity.java
@@ -3,10 +3,7 @@ package de.muenchen.service;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.search.annotations.IndexedEmbedded;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.io.Serializable;
 
 /**
@@ -14,6 +11,7 @@ import java.io.Serializable;
  * @author claus.straube
  */
 @MappedSuperclass
+@EntityListeners(DatabaseBeforeSaveEventListener.class)
 public abstract class BaseEntity implements Cloneable, Serializable {
 
     @Column(name = "OID")

--- a/Service-Lib/src/main/java/de/muenchen/service/BaseEntity.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/BaseEntity.java
@@ -3,7 +3,10 @@ package de.muenchen.service;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.search.annotations.IndexedEmbedded;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
 import java.io.Serializable;
 
 /**

--- a/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
@@ -9,8 +9,10 @@ import javax.persistence.PrePersist;
 public class DatabaseBeforeSaveEventListener {
 
     @PrePersist
-    public void addOid(Object object){
+    public void addOid(Object object) {
         BaseEntity entity = (BaseEntity) object;
-        entity.setOid(IdService.next());
+        //TODO Hackfür die Tests. Soll das wirklich möglich sein?
+        if (entity.getOid() == null)
+            entity.setOid(IdService.next());
     }
 }

--- a/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
@@ -1,0 +1,16 @@
+package de.muenchen.service;
+
+import javax.persistence.PrePersist;
+
+/**
+ * Created by claus.straube on 28.10.15.
+ * fabian.holtkoetter ist unschuldig.
+ */
+public class DatabaseBeforeSaveEventListener {
+
+    @PrePersist
+    public void addOid(Object object){
+        BaseEntity entity = (BaseEntity) object;
+        entity.setOid(IdService.next());
+    }
+}

--- a/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
@@ -5,9 +5,15 @@ import javax.persistence.PrePersist;
 /**
  * Created by claus.straube on 28.10.15.
  * fabian.holtkoetter ist unschuldig.
+ *
+ * Wird von BaseEntity verwendet, um das setzen der OID einer Entität vor dem Speichern in der Datenbank zu ermöglichen.
  */
 public class DatabaseBeforeSaveEventListener {
 
+    /**
+     * Setzt die OID der zu speichernden Entität vor dem Speichern in der Datenbank
+     * @param object
+     */
     @PrePersist
     public void addOid(Object object) {
         BaseEntity entity = (BaseEntity) object;

--- a/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/DatabaseBeforeSaveEventListener.java
@@ -1,5 +1,8 @@
 package de.muenchen.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.persistence.PrePersist;
 
 /**
@@ -10,6 +13,8 @@ import javax.persistence.PrePersist;
  */
 public class DatabaseBeforeSaveEventListener {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DatabaseBeforeSaveEventListener.class);
+
     /**
      * Setzt die OID der zu speichernden Entität vor dem Speichern in der Datenbank
      * @param object
@@ -17,7 +22,6 @@ public class DatabaseBeforeSaveEventListener {
     @PrePersist
     public void addOid(Object object) {
         BaseEntity entity = (BaseEntity) object;
-        //TODO Hackfür die Tests. Soll das wirklich möglich sein?
         if (entity.getOid() == null)
             entity.setOid(IdService.next());
     }

--- a/Service-Lib/src/main/java/de/muenchen/service/RepoBeforeSaveEventListener.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/RepoBeforeSaveEventListener.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
  * Created by p.mueller on 11.09.15.
  */
 @Component
-public class BeforeSaveEventListener extends AbstractRepositoryEventListener<BaseEntity> {
+public class RepoBeforeSaveEventListener extends AbstractRepositoryEventListener<BaseEntity> {
 
     @Autowired
     UserRepository userRepository;
@@ -20,7 +20,6 @@ public class BeforeSaveEventListener extends AbstractRepositoryEventListener<Bas
     @Override
     protected void onBeforeCreate(BaseEntity entity) {
         entity.setMandant(getCurrentMandant());
-        entity.setOid(IdService.next());
     }
 
     public String getCurrentMandant() {

--- a/vaadin-demo-micro-service/src/main/java/de/muenchen/demo/service/gen/domain/Buerger.java
+++ b/vaadin-demo-micro-service/src/main/java/de/muenchen/demo/service/gen/domain/Buerger.java
@@ -3,6 +3,7 @@ package de.muenchen.demo.service.gen.domain;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import de.muenchen.auditing.MUCAudited;
 import de.muenchen.service.BaseEntity;
 import de.muenchen.service.PetersPerfectBridge;
 import org.hibernate.search.annotations.Field;
@@ -33,6 +34,7 @@ import java.util.Set;
 @Entity
 @Indexed
 @Table(name = "BUERGER")
+@MUCAudited({MUCAudited.CREATE, MUCAudited.DELETE})
 public class Buerger extends BaseEntity {
 
     // ========= //

--- a/vaadin-demo-micro-service/src/main/java/de/muenchen/demo/service/gen/domain/Buerger.java
+++ b/vaadin-demo-micro-service/src/main/java/de/muenchen/demo/service/gen/domain/Buerger.java
@@ -73,13 +73,15 @@ public class Buerger extends BaseEntity {
     //TODO @NotNull
     private Augenfarben augenfarbe;
 
-
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "oid")
+    @JsonIdentityReference(alwaysAsId = true)
     @JoinTable(name = "buergers_wohnungens", joinColumns = {@JoinColumn(name = "buerger_oid")}, inverseJoinColumns = {@JoinColumn(name = "wohnungen_oid")})
     @OneToOne(cascade = {CascadeType.REFRESH}, fetch = FetchType.EAGER)
     //TODO @NotNull
     private Wohnung wohnungen;
 
-
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "oid")
+    @JsonIdentityReference(alwaysAsId = true)
     @JoinTable(name = "buergers_staatsangehoerigkeitens", joinColumns = {@JoinColumn(name = "buerger_oid")}, inverseJoinColumns = {@JoinColumn(name = "staatsangehoerigkeiten_oid")})
     @ManyToMany
     @NotNull
@@ -99,25 +101,23 @@ public class Buerger extends BaseEntity {
     @OneToOne(cascade = {CascadeType.REFRESH}, fetch = FetchType.EAGER)
     private Buerger partner;
 
-
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "oid")
+    @JsonIdentityReference(alwaysAsId = true)
     @JoinTable(name = "buergers_sachbearbeiters", joinColumns = {@JoinColumn(name = "buerger_oid")}, inverseJoinColumns = {@JoinColumn(name = "sachbearbeiter_oid")})
     @ManyToMany
     @NotNull
     private java.util.Collection<Sachbearbeiter> sachbearbeiter = new ArrayList<>();
-    ;
 
-
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "oid")
+    @JsonIdentityReference(alwaysAsId = true)
     @JoinTable(name = "buergers_paesses", joinColumns = {@JoinColumn(name = "buerger_oid")}, inverseJoinColumns = {@JoinColumn(name = "paesse_oid")})
     @OneToMany(cascade = {CascadeType.REFRESH}, fetch = FetchType.EAGER)
     @NotNull
     private java.util.Collection<Pass> paesse = new ArrayList<>();
-    ;
-
 
     @Column(name = "alive")
     @NotNull
     private Boolean alive;
-
 
     @Field
     @FieldBridge(impl = PetersPerfectBridge.class)

--- a/vaadin-demo-micro-service/src/main/resources/application.properties
+++ b/vaadin-demo-micro-service/src/main/resources/application.properties
@@ -17,8 +17,8 @@ spring.messages.encoding: UTF-8
 flyway.clean-on-validation-error=true
 
 # DB
-spring.datasource.url: jdbc:h2:mem:data_ref
-#spring.datasource.url: jdbc:h2:tcp://localhost/~/java_data
+#spring.datasource.url: jdbc:h2:mem:data_ref
+spring.datasource.url: jdbc:h2:tcp://localhost/~/java_data
 spring.datasource.username: sa
 spring.datasource.password:
 spring.datasource.driverClassName: org.h2.Driver

--- a/vaadin-demo-micro-service/src/main/resources/application.properties
+++ b/vaadin-demo-micro-service/src/main/resources/application.properties
@@ -17,8 +17,8 @@ spring.messages.encoding: UTF-8
 flyway.clean-on-validation-error=true
 
 # DB
-#spring.datasource.url: jdbc:h2:mem:data_ref
-spring.datasource.url: jdbc:h2:tcp://localhost/~/java_data
+spring.datasource.url: jdbc:h2:mem:data_ref
+#spring.datasource.url: jdbc:h2:tcp://localhost/~/java_data
 spring.datasource.username: sa
 spring.datasource.password:
 spring.datasource.driverClassName: org.h2.Driver


### PR DESCRIPTION
## Beschreibung:

Die OID einer Entität wird nun vor dem Speichern in der Datenbank gesetzt, und nicht wie vorher zwischen REST-Schnittstelle und Repository. Dadurch ist es jetzt möglich auch über Business-Actions Entitäten zu erstellen.
Der Mandant wird weiterhin zwischen Rest-Schnittstelle und Repository gesetzt, da es auf Ebene des EntityListeners von JPA nicht möglich ist, durch `@Autowired` an das `UserRepsotiory` zu kommen. Somit muss der Mandant beim erstellen von Entitäten innerhalb einer BusinessAction händisch gesetzt werden. Dies wird noch im Wiki dokumentiert.
## Branch-Checklist:
- [x] Doku im Code vollständig
- [x] Im Wiki dokumentiert
- [x] MicroService getestet
- [x] GUI getestet
- [x] keine \* Imports
- [ ] Barakuda Issue erstellt
## Bestätigungen:
- [x] @peter-mueller 
- [x] @darenegade 
## Referenz:

closes #189 
