### PR TITLE
Grid blendet nicht Field Propertys aus

### DIFF
--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
@@ -758,6 +758,7 @@ public class GenericGrid<T> extends BaseComponent {
 
         grid.setContainerDataSource(container);
 
+        //Remove Columns from Conatiner which are not present in Field enum
         container.getContainerPropertyIds().stream()
                 .filter(property -> !fields.contains(property))
                 .forEach(container::removeContainerProperty);

--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/components/GenericGrid.java
@@ -758,6 +758,11 @@ public class GenericGrid<T> extends BaseComponent {
 
         grid.setContainerDataSource(container);
 
+        container.getContainerPropertyIds().stream()
+                .filter(property -> !fields.contains(property))
+                .forEach(container::removeContainerProperty);
+
+
         grid.setColumnOrder(fields.toArray());
 
         fields.forEach(field ->


### PR DESCRIPTION
## Beschreibung:

Die Grid blendet Felder aus, die nicht im Field Enum stehen.
## Branch-Checklist:
- [x] Doku im Code vollständig
- [ ] Im Wiki dokumentiert
- [x] GUI getestet
- [x] keine \* Imports
## Bestätigungen:
- [ ] @FabianHoltkoetter
## Referenz:

closes #280 
