### PR TITLE
User vor/nachname können jetzt länger als ein Buchstabe sein

### DIFF
--- a/Service-Lib/src/main/java/de/muenchen/service/security/entities/User.java
+++ b/Service-Lib/src/main/java/de/muenchen/service/security/entities/User.java
@@ -44,14 +44,14 @@ public class User extends BaseEntity implements Serializable {
     @Field
     @Column(name = "USER_FORNAME")
     @NotNull
-    @Pattern(regexp="\\p{L}")
+    @Pattern(regexp="\\S*")
     @Size(min=1)
     private String forname;
 
     @Field
     @Column(name = "USER_SURNAME")
     @NotNull
-    @Pattern(regexp = "\\p{L}")
+    @Pattern(regexp = "\\S*")
     @Size(min=1)
     private String surname;
 


### PR DESCRIPTION
## Beschreibung:

 Service-Lib validiert jetzt nutzer auf Vor/Nachnamen mit mindestens einen statt exakt eine Buchstaben
## Branch-Checklist:
- [x] MicroService getestet
- [x] GUI getestet
- [x] keine \* Imports
## Bestätigungen:
- [x] @FabianHoltkoetter
## Referenz:

closes #291 
