### PR TITLE
Beispiel mit Nutzung von Horizontal- statt CSS-Layout

### DIFF
--- a/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/util/FormUtil.java
+++ b/GUI-Lib/src/main/java/de/muenchen/vaadin/guilib/util/FormUtil.java
@@ -10,6 +10,7 @@ import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.DateField;
+import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.PasswordField;
 import com.vaadin.ui.TextArea;
 import com.vaadin.ui.TextField;
@@ -286,8 +287,12 @@ public class FormUtil {
         final String caption = getCaption(property);
         final String tooltip = getTooltip(property);
         //Group Elements of TokenField in CSS Layout
-        CssLayout lo = new CssLayout();
+
+        HorizontalLayout lo = new HorizontalLayout();
+        lo.addStyleName(ValoTheme.LAYOUT_HORIZONTAL_WRAPPING);
+        lo.setSpacing(true);
         lo.addStyleName("v-component-group");
+
 
         TokenField tf = new TokenField(caption, lo) {
             public static final String SEPERATOR = ",";


### PR DESCRIPTION
## Beschreibung:

Mit den Änderungen an diesem Branch kann das Tokenfield Zeilenumbruch. Bitte jeder mal in das Ticket reinschauen und sagen, ob das besser ist. 

http://strawpoll.me/6606457
## Branch-Checklist:
- [x] GUI getestet
- [x] keine \* Imports
## Bestätigungen:
- jeder der mag.
## Referenz:

closes #286
